### PR TITLE
Feat self instrospection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,16 +63,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -104,6 +262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +294,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -271,10 +446,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lalrpop-util"
@@ -350,7 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
 dependencies = [
  "hashbrown",
- "itertools",
+ "itertools 0.11.0",
  "libm",
  "ryu",
 ]
@@ -374,7 +568,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "libm",
  "malachite-base",
 ]
@@ -385,7 +579,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "malachite-base",
  "malachite-nz",
 ]
@@ -419,6 +613,22 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "paste"
@@ -513,6 +723,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +817,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +891,7 @@ checksum = "51e73421499eff08722b979d8494c3f1bc035908931a28607a9f17be6143ac11"
 dependencies = [
  "anyhow",
  "is-macro",
- "itertools",
+ "itertools 0.11.0",
  "lalrpop-util",
  "log",
  "malachite-bigint",
@@ -642,10 +929,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -705,6 +1007,7 @@ dependencies = [
 name = "shapels"
 version = "0.4.1"
 dependencies = [
+ "criterion",
  "lsp-server",
  "lsp-types",
  "phf 0.13.1",
@@ -713,6 +1016,12 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -797,6 +1106,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -916,10 +1235,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,19 @@ serde_json = "1.0"
 phf = { version = "0.13.1"}
 phf_macros = "0.13.1"
 
+[dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
+
 [lib]
 name = "shapels"
 path = "src/lib.rs"
+bench = false
 
 [[bin]]
 name = "shapels"
 path = "src/main.rs"
+bench = false
+
+[[bench]]
+name = "bench_selected_tests"
+harness = false

--- a/benches/bench_selected_tests.rs
+++ b/benches/bench_selected_tests.rs
@@ -1,0 +1,85 @@
+use criterion::BenchmarkId;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::path::Path;
+
+use shapels::{ModuleCache, analyze_source_at_path, analyze_source_at_path_with_cache};
+
+const PY_MULTIFILE_DATA: &str = include_str!("../test_data/multi_caller.py");
+const PY_VIEW_DATA: &str = include_str!("../test_data/view.py");
+const PY_UNET_DATA: &str = include_str!("../test_data/unet.py");
+
+pub fn extract_test_case(py_data: &'static str, n: usize) -> String {
+    let marker = format!("# test {n}");
+    let mut buf = Vec::new();
+    let mut capture = false;
+    for line in py_data.lines() {
+        if line.trim() == marker {
+            capture = true;
+            continue;
+        }
+        if capture && line.starts_with("# test ") {
+            break;
+        }
+        if capture {
+            buf.push(line);
+        }
+    }
+    buf.join("\n")
+}
+
+fn analyse_and_count_diagnostics(src: &str, path: &Path) -> usize {
+    let analysis = analyze_source_at_path(&src, path);
+    analysis.diagnostics.len()
+}
+
+fn analyse_cached_and_count_diagnostics(
+    src: &str,
+    path: &Path,
+    module_cache: &mut ModuleCache,
+) -> usize {
+    let analysis = analyze_source_at_path_with_cache(&src, path, module_cache);
+    analysis.diagnostics.len()
+}
+
+fn parse_unet(c: &mut Criterion) {
+    let path = Path::new("test_data/unet.py");
+    let mut module_cache = ModuleCache::new();
+    c.bench_function("Unet analysis", |b| {
+        b.iter(|| analyse_cached_and_count_diagnostics(PY_UNET_DATA, &path, &mut module_cache))
+    });
+}
+
+fn multifile_tests(c: &mut Criterion) {
+    let mut group = c.benchmark_group("MultiFile");
+    let path = Path::new("test_data/multi_caller.py");
+    for test_idx in 1..11 {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(test_idx),
+            &test_idx,
+            |b, &test_idx| {
+                let test_src = extract_test_case(PY_MULTIFILE_DATA, test_idx);
+                b.iter(|| analyse_and_count_diagnostics(test_src.as_str(), &path));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn view_tests(c: &mut Criterion) {
+    let mut group = c.benchmark_group("View");
+    let path = Path::new("test_data/view.py");
+    for test_idx in 1..19 {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(test_idx),
+            &test_idx,
+            |b, &test_idx| {
+                let test_src = extract_test_case(PY_VIEW_DATA, test_idx);
+                b.iter(|| analyse_and_count_diagnostics(test_src.as_str(), &path));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, parse_unet, multifile_tests, view_tests);
+criterion_main!(benches);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
-use crate::analyze_source_at_path;
 use lsp_types::DiagnosticSeverity;
 use shapels::Analysis;
+use shapels::analyze_source_at_path;
 use std::io::{self, BufWriter, Write};
 use std::{env, path::PathBuf};
 use std::{fs::read_to_string, path::Path, process::exit};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,10 @@ struct VarState {
     class_ref: Option<ClassRef>,
 }
 
+fn state_shape(state: &VarState) -> Option<&Shape> {
+    state.annotated.as_ref().or(state.inferred.as_ref())
+}
+
 /// Output of [`simulate_function`], such that return type
 /// can be recorded and matched against tuple destructuring on
 /// assignment.
@@ -565,8 +569,8 @@ fn simulate_block(
                             );
                         }
                     }
-                    if let (Some(ann), Some(inf)) = (ann_shape.clone(), inferred.clone())
-                        && !shape_dims_equal(&ann, &inf)
+                    if let (Some(ann), Some(inf)) = (ann_shape.as_ref(), inferred.as_ref())
+                        && !shape_dims_equal(ann, inf)
                     {
                         // If annotation is a shape-unroll, treat it as a rename rather than mismatch.
                         if let Expr::Subscript(_sub) = &*assign.annotation
@@ -642,7 +646,7 @@ fn simulate_block(
                             VarState {
                                 annotated: ann_shape.clone(),
                                 inferred: None,
-                                class_ref: Some(class_ref),
+                                class_ref: Some(class_ref.into_owned()),
                             },
                         );
                     }
@@ -745,7 +749,7 @@ fn simulate_block(
                             VarState {
                                 annotated: None,
                                 inferred: None,
-                                class_ref: Some(class_ref),
+                                class_ref: Some(class_ref.into_owned()),
                             },
                         );
                     }
@@ -1112,7 +1116,7 @@ fn infer_expr_shape(
                 module_path,
             ) && let Some(ret) = infer_class_call_return(
                 call,
-                &class_ref,
+                class_ref.as_ref(),
                 vars,
                 func_map,
                 imports,
@@ -1223,7 +1227,7 @@ fn infer_expr_shape(
                     module_path,
                 ) && let Some(ret) = infer_class_method_call_return(
                     call,
-                    &class_ref,
+                    class_ref.as_ref(),
                     &attr.attr,
                     vars,
                     func_map,
@@ -1382,9 +1386,7 @@ fn infer_expr_shape(
             if report_unbound_self_diagnostic(expr, vars, diagnostics, source) {
                 return None;
             }
-            let shape = vars
-                .get(&expr_name.id)
-                .and_then(|v| v.annotated.clone().or_else(|| v.inferred.clone()));
+            let shape = vars.get(&expr_name.id).and_then(state_shape).cloned();
             if record_hovers && let Some(s) = shape.clone() {
                 let range = text_range_to_lsp(expr_text_range(expr), source);
                 hover_entries.push((range, HoverInfo { shape: Some(s) }));
@@ -1961,7 +1963,7 @@ fn infer_call_return_from_info(
                     VarState {
                         annotated: None,
                         inferred: None,
-                        class_ref: Some(class_ref),
+                        class_ref: Some(class_ref.into_owned()),
                     },
                 );
             }
@@ -2086,7 +2088,10 @@ fn infer_class_member_call_return(
                     if !class_info.is_torch_module {
                         return None;
                     }
-                    class_info.forward.as_ref()?
+                    class_info
+                        .forward_name
+                        .as_ref()
+                        .and_then(|name| class_info.methods.get(name))?
                 }
                 ClassCallable::Method(method_name) => class_info.methods.get(method_name)?,
             };
@@ -2215,7 +2220,7 @@ fn infer_defined_call_return(
     ) {
         return infer_class_call_return(
             call,
-            &class_ref,
+            class_ref.as_ref(),
             vars,
             func_map,
             imports,
@@ -2299,7 +2304,7 @@ fn infer_defined_call_return(
     {
         return infer_class_method_call_return(
             call,
-            &class_ref,
+            class_ref.as_ref(),
             &attr.attr,
             vars,
             func_map,
@@ -2408,9 +2413,7 @@ fn lookup_shape(
 ) -> Option<Shape> {
     match expr {
         Expr::Name(expr_name) => {
-            let shape = vars
-                .get(&expr_name.id)
-                .and_then(|v| v.annotated.clone().or_else(|| v.inferred.clone()));
+            let shape = vars.get(&expr_name.id).and_then(state_shape).cloned();
             if record_hovers && let Some(s) = shape.clone() {
                 let range = text_range_to_lsp(expr_text_range(expr), source);
                 hover_entries.push((range, HoverInfo { shape: Some(s) }));
@@ -2479,7 +2482,7 @@ fn assignment_shape_checks(
 
     let range = text_range_to_lsp(expr_text_range(value), source);
     let existing_state = vars.get(&base_id);
-    let existing_shape = existing_state.and_then(|v| v.annotated.clone().or(v.inferred.clone()));
+    let existing_shape = existing_state.and_then(state_shape);
 
     if let Some(shape) = existing_shape {
         if shape.dims.len() == dims.len() {
@@ -2645,16 +2648,12 @@ fn seed_args_from_annotations(
                 })
                 .or(union_class),
         };
+        let hover_shape = state_shape(&state).cloned();
 
         if state.annotated.is_some() || state.inferred.is_some() || state.class_ref.is_some() {
-            vars.insert(arg.def.arg.clone(), state.clone());
+            vars.insert(arg.def.arg.clone(), state);
             if record_hovers {
-                hover_entries.push((
-                    range,
-                    HoverInfo {
-                        shape: state.annotated.or(state.inferred),
-                    },
-                ));
+                hover_entries.push((range, HoverInfo { shape: hover_shape }));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,9 +549,7 @@ fn simulate_block(
                             record_hovers,
                             source,
                         ) {
-                            inferred = vars
-                                .get(&name)
-                                .and_then(|v| v.annotated.clone().or(v.inferred.clone()));
+                            inferred = vars.get(&name).and_then(state_shape).cloned();
                         } else {
                             inferred = infer_expr_shape(
                                 val,
@@ -616,12 +614,14 @@ fn simulate_block(
                             data: None,
                         });
                     }
-                    let chosen_shape = ann_shape.clone().or(inferred.clone());
+                    let annotated = ann_shape.clone();
+                    let inferred = inferred;
+                    let chosen_shape = annotated.clone().or_else(|| inferred.clone());
                     if let Some(shape) = chosen_shape {
                         vars.insert(
                             name.clone(),
                             VarState {
-                                annotated: ann_shape.clone(),
+                                annotated,
                                 inferred,
                                 class_ref: None,
                             },
@@ -2636,7 +2636,7 @@ fn seed_args_from_annotations(
         let range = text_range_to_lsp(arg.def.range, source);
         let provided_state = provided.as_ref().and_then(|p| p.get(&arg.def.arg));
         let state = VarState {
-            annotated: ann_shape.clone().or(union_shape),
+            annotated: ann_shape.or(union_shape),
             inferred: provided_state.and_then(|s| s.inferred.clone()),
             class_ref: provided_state
                 .and_then(|s| s.class_ref.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ use crate::infer::{
 };
 pub use crate::module_resolution::ModuleCache;
 use crate::module_resolution::{
-    ClassMap, ClassRef, FuncMap, FunctionInfo, class_ref_from_annotation, class_ref_from_expr,
-    collect_class_defs, collect_function_defs, method_param_offset, with_class_info,
+    ClassMap, ClassRef, FuncMap, FunctionInfo, attr_state_from_expr, class_ref_from_annotation,
+    class_ref_from_expr, collect_class_defs, collect_function_defs, is_parameter_constructor,
+    method_param_offset, with_class_info,
 };
 pub use crate::op_groups::AGGR_ALIASES;
 use crate::op_groups::{BroadcastOp, Imports, TORCH_DTYPES, TorchOp, collect_imports};
@@ -110,6 +111,46 @@ struct VarState {
 
 fn state_shape(state: &VarState) -> Option<&Shape> {
     state.annotated.as_ref().or(state.inferred.as_ref())
+}
+
+fn push_assignment_hover(
+    hover_entries: &mut Vec<(Range, HoverInfo)>,
+    target: &Expr,
+    source: &str,
+    shape: Shape,
+) {
+    let range = text_range_to_lsp(expr_text_range(target), source);
+    hover_entries.push((
+        range,
+        HoverInfo {
+            shape: Some(shape.clone()),
+        },
+    ));
+    hover_entries.push((
+        Range {
+            start: range.start,
+            end: range.start,
+        },
+        HoverInfo { shape: Some(shape) },
+    ));
+}
+
+fn self_attr_name(expr: &Expr) -> Option<Identifier> {
+    let Expr::Attribute(attr) = expr else {
+        return None;
+    };
+    let Expr::Name(name) = attr.value.as_ref() else {
+        return None;
+    };
+    (name.id.as_str() == "self").then(|| attr.attr.clone())
+}
+
+fn self_attr_storage_key(attr: &Identifier) -> Identifier {
+    Identifier::from(format!("self.{}", attr.as_str()))
+}
+
+fn expr_var_key(expr: &Expr) -> Option<Identifier> {
+    name_from_expr(expr).or_else(|| self_attr_name(expr).map(|attr| self_attr_storage_key(&attr)))
 }
 
 /// Output of [`simulate_function`], such that return type
@@ -246,6 +287,22 @@ fn analyze_source_internal<'a>(
     mut module_cache: Option<&mut ModuleCache>,
 ) -> Analysis {
     let mut analysis = Analysis::default();
+    if let (Some(path), Some(cache)) = (current_path, module_cache.as_deref_mut())
+        && let Some(module) = cache.get_file_module(path, Some(source))
+    {
+        analyze_module(
+            &module.body,
+            &module.source,
+            &module.func_map,
+            &module.imports,
+            &module.class_map,
+            &mut analysis,
+            module_cache,
+            Some(module.file_path.as_path()),
+        );
+        return analysis;
+    }
+
     let normalized = normalize_return_annotations(source);
     let source = normalized.as_ref();
     let parse_name = current_path
@@ -259,40 +316,10 @@ fn analyze_source_internal<'a>(
                     .and_then(|cache| cache.project_root_for(path))
             });
             let imports = collect_imports(&module, current_path, project_root.as_deref());
-            // collect function definitions first
             let mut func_map: FuncMap = HashMap::new();
             collect_function_defs(&module, &mut func_map);
             let class_map = collect_class_defs(&module, &imports);
-
-            // analyze top-level statements (outside functions)
-            let empty_args = Arguments {
-                range: ast::OptionalRange::from(TextRange::new(
-                    TextSize::from(0),
-                    TextSize::from(0),
-                )),
-                posonlyargs: Vec::new(),
-                args: Vec::new(),
-                vararg: None,
-                kwonlyargs: Vec::new(),
-                kwarg: None,
-            };
-            let (mut top_diags, mut top_hovers, _) = simulate_function(
-                &empty_args,
-                &module,
-                source,
-                &func_map,
-                &imports,
-                &class_map,
-                &mut Vec::new(),
-                HashMap::new(),
-                true,
-                module_cache.as_deref_mut(),
-                current_path,
-            );
-            analysis.diagnostics.append(&mut top_diags);
-            analysis.hover_entries.append(&mut top_hovers);
-
-            analyze_function_bodies(
+            analyze_module(
                 &module,
                 source,
                 &func_map,
@@ -301,7 +328,6 @@ fn analyze_source_internal<'a>(
                 &mut analysis,
                 module_cache,
                 current_path,
-                None,
             );
         }
         Err(err) => {
@@ -319,6 +345,53 @@ fn analyze_source_internal<'a>(
         }
     }
     analysis
+}
+
+fn analyze_module(
+    module: &[Stmt],
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    analysis: &mut Analysis,
+    mut module_cache: Option<&mut ModuleCache>,
+    current_path: Option<&Path>,
+) {
+    let empty_args = Arguments {
+        range: ast::OptionalRange::from(TextRange::new(TextSize::from(0), TextSize::from(0))),
+        posonlyargs: Vec::new(),
+        args: Vec::new(),
+        vararg: None,
+        kwonlyargs: Vec::new(),
+        kwarg: None,
+    };
+    let (mut top_diags, mut top_hovers, _) = simulate_function(
+        &empty_args,
+        module,
+        source,
+        func_map,
+        imports,
+        class_map,
+        &mut Vec::new(),
+        HashMap::new(),
+        true,
+        module_cache.as_deref_mut(),
+        current_path,
+    );
+    analysis.diagnostics.append(&mut top_diags);
+    analysis.hover_entries.append(&mut top_hovers);
+
+    analyze_function_bodies(
+        module,
+        source,
+        func_map,
+        imports,
+        class_map,
+        analysis,
+        module_cache,
+        current_path,
+        None,
+    );
 }
 
 /// Iterate over the function and classes of a module `body`.
@@ -545,7 +618,7 @@ fn simulate_block(
                 ) {
                     continue;
                 }
-                if let Some(name) = name_from_expr(&assign.target) {
+                if let Some(name) = expr_var_key(&assign.target) {
                     let ann_shape = parse_shape_annotation(&assign.annotation);
                     let range = text_range_to_lsp(expr_text_range(&assign.target), source);
                     let mut inferred = None;
@@ -599,12 +672,12 @@ fn simulate_block(
                                 },
                             );
                             if record_hovers {
-                                hover_entries.push((
-                                    range,
-                                    HoverInfo {
-                                        shape: Some(renamed),
-                                    },
-                                ));
+                                push_assignment_hover(
+                                    hover_entries,
+                                    &assign.target,
+                                    source,
+                                    renamed,
+                                );
                             }
                             continue;
                         }
@@ -637,7 +710,7 @@ fn simulate_block(
                             },
                         );
                         if record_hovers {
-                            hover_entries.push((range, HoverInfo { shape: Some(shape) }));
+                            push_assignment_hover(hover_entries, &assign.target, source, shape);
                         }
                     } else if let Some(val) = &assign.value
                         && let Some(class_ref) = class_ref_from_expr(
@@ -715,9 +788,8 @@ fn simulate_block(
                     continue;
                 }
                 if assign.targets.len() == 1
-                    && let Some(name) = name_from_expr(&assign.targets[0])
+                    && let Some(name) = expr_var_key(&assign.targets[0])
                 {
-                    let range = text_range_to_lsp(expr_text_range(&assign.targets[0]), source);
                     let shape = infer_expr_shape(
                         &assign.value,
                         vars,
@@ -742,7 +814,7 @@ fn simulate_block(
                             },
                         );
                         if record_hovers {
-                            hover_entries.push((range, HoverInfo { shape: Some(shape) }));
+                            push_assignment_hover(hover_entries, &assign.targets[0], source, shape);
                         }
                     } else if let Some(class_ref) = class_ref_from_expr(
                         &assign.value,
@@ -983,7 +1055,7 @@ fn simulate_block(
 ///
 /// This is the central function for inference, it calls the specialized
 /// inference at src/infer.rs depending on type of the expression.
-fn infer_expr_shape(
+pub(crate) fn infer_expr_shape(
     expr: &Expr,
     vars: &HashMap<Identifier, VarState>,
     func_map: &FuncMap,
@@ -1114,6 +1186,24 @@ fn infer_expr_shape(
         Expr::Call(call) => {
             if report_unbound_self_diagnostic(call.func.as_ref(), vars, diagnostics, source) {
                 return None;
+            }
+            if is_parameter_constructor(call.func.as_ref(), imports)
+                && let Some(base) = call.args.first()
+            {
+                return infer_expr_shape(
+                    base,
+                    vars,
+                    func_map,
+                    imports,
+                    class_map,
+                    call_stack,
+                    diagnostics,
+                    hover_entries,
+                    record_hovers,
+                    source,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                );
             }
             if let Some(class_ref) = class_ref_from_expr(
                 call.func.as_ref(),
@@ -1390,18 +1480,32 @@ fn infer_expr_shape(
                         )
                     });
             }
-            None
-        }
-        Expr::Name(expr_name) => {
-            if report_unbound_self_diagnostic(expr, vars, diagnostics, source) {
-                return None;
+            if let Some(shape) = lookup_shape(expr, vars, hover_entries, record_hovers, source) {
+                return Some(shape);
             }
-            let shape = vars.get(&expr_name.id).and_then(state_shape).cloned();
+            let shape = attr_state_from_expr(
+                expr,
+                vars,
+                source,
+                func_map,
+                imports,
+                class_map,
+                module_cache.as_deref_mut(),
+                module_path,
+            )
+            .and_then(|state| state_shape(&state).cloned());
             if record_hovers && let Some(s) = shape.clone() {
                 let range = text_range_to_lsp(expr_text_range(expr), source);
                 hover_entries.push((range, HoverInfo { shape: Some(s) }));
             }
             shape
+        }
+        Expr::Name(expr_name) => {
+            if report_unbound_self_diagnostic(expr, vars, diagnostics, source) {
+                return None;
+            }
+            let _ = expr_name;
+            lookup_shape(expr, vars, hover_entries, record_hovers, source)
         }
         _ => None,
     }
@@ -2431,17 +2535,13 @@ fn lookup_shape(
     record_hovers: bool,
     source: &str,
 ) -> Option<Shape> {
-    match expr {
-        Expr::Name(expr_name) => {
-            let shape = vars.get(&expr_name.id).and_then(state_shape).cloned();
-            if record_hovers && let Some(s) = shape.clone() {
-                let range = text_range_to_lsp(expr_text_range(expr), source);
-                hover_entries.push((range, HoverInfo { shape: Some(s) }));
-            }
-            shape
-        }
-        _ => None,
+    let key = expr_var_key(expr)?;
+    let shape = vars.get(&key).and_then(state_shape).cloned();
+    if record_hovers && let Some(s) = shape.clone() {
+        let range = text_range_to_lsp(expr_text_range(expr), source);
+        hover_entries.push((range, HoverInfo { shape: Some(s) }));
     }
+    shape
 }
 
 /// An operation might be a function `torch.FUNCTION` (might be imported and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,20 @@ use rustpython_parser::text_size::{TextRange, TextSize};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 mod infer;
+mod module_resolution;
 pub mod op_groups;
 use crate::infer::{
     ShapeOrExpr, Transpose, infer_broadcastable_poswise, infer_conv, infer_creation_size,
     infer_flatten, infer_index, infer_matmul_shapes, infer_noop, infer_permute, infer_range_size,
     infer_repeat, infer_repeat_interleave, infer_squeeze, infer_to, infer_unsqueeze,
     infer_view_like, shape_dims_equal,
+};
+use crate::module_resolution::{
+    ClassMap, ClassRef, FuncMap, FunctionInfo, ModuleCache, class_ref_from_annotation,
+    class_ref_from_expr, collect_class_defs, collect_function_defs, method_param_offset,
+    with_class_info,
 };
 pub use crate::op_groups::AGGR_ALIASES;
 use crate::op_groups::{BroadcastOp, Imports, TORCH_DTYPES, TorchOp, collect_imports};
@@ -146,83 +152,6 @@ impl ReturnValue {
     }
 }
 
-#[derive(Clone)]
-struct FunctionInfo {
-    args: Box<Arguments>,
-    body: Vec<Stmt>,
-    returns: Option<Box<Expr>>,
-}
-
-type FuncMap = HashMap<Identifier, FunctionInfo>;
-
-#[derive(Debug, Clone)]
-struct ClassRef {
-    name: Identifier,
-    module: Option<String>,
-}
-
-#[derive(Clone)]
-struct ClassInfo {
-    is_torch_module: bool,
-    forward: Option<FunctionInfo>,
-    methods: HashMap<Identifier, FunctionInfo>,
-}
-
-type ClassMap = HashMap<Identifier, ClassInfo>;
-
-#[derive(Clone)]
-pub(crate) struct CachedModule {
-    path: PathBuf,
-    source: String,
-    func_map: FuncMap,
-    imports: Imports,
-    class_map: ClassMap,
-}
-
-pub(crate) struct ModuleCache {
-    modules: HashMap<String, CachedModule>,
-    project_root: Option<PathBuf>,
-}
-
-impl ModuleCache {
-    fn new(current_file: &Path) -> Self {
-        let project_root = find_project_root(current_file);
-        Self {
-            modules: HashMap::new(),
-            project_root,
-        }
-    }
-
-    fn project_root(&self) -> Option<&Path> {
-        self.project_root.as_deref()
-    }
-
-    /// Return a cloned module entry, loading and parsing it if necessary.
-    fn get_module(&mut self, module_name: &str, current_file: &Path) -> Option<CachedModule> {
-        if let Some(cached) = self.modules.get(module_name) {
-            return Some(cached.clone());
-        }
-        let path = resolve_module_path(module_name, current_file, self.project_root.as_deref())?;
-        let source = fs::read_to_string(&path).ok()?;
-        let normalized = normalize_return_annotations(&source);
-        let source = normalized.into_owned();
-        let module = Suite::parse(&source, module_name).ok()?;
-        let imports = collect_imports(&module, Some(&path), self.project_root());
-        let mut func_map: FuncMap = HashMap::new();
-        collect_function_defs(&module, &mut func_map);
-        let class_map = collect_class_defs(&module, &imports);
-        let cached = CachedModule {
-            path,
-            source,
-            func_map,
-            imports,
-            class_map,
-        };
-        self.modules.insert(module_name.to_string(), cached.clone());
-        Some(cached)
-    }
-}
-
 /// Normalize return annotations so `-> A, B` parses as `-> (A, B)`.
 fn normalize_return_annotations<'a>(source: &'a str) -> Cow<'a, str> {
     let mut changed = false;
@@ -258,182 +187,14 @@ fn normalize_return_annotations<'a>(source: &'a str) -> Cow<'a, str> {
     }
 }
 
-fn find_project_root(start: &Path) -> Option<PathBuf> {
-    let mut dir = start.parent();
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    while let Some(current) = dir {
-        if current.join(".git").exists()
-            || current.join("pyproject.toml").exists()
-            || current.join("setup.py").exists()
-            || current.join("setup.cfg").exists()
-        {
-            return Some(current.to_path_buf());
-        }
-        if Some(current.to_path_buf()) == home {
-            break;
-        }
-        dir = current.parent();
-    }
-    None
-}
-
-/// Resolve a class reference across local/module context and run a callback with its info.
-fn with_class_info<R, F>(
-    class_ref: &ClassRef,
-    source: &str,
-    func_map: &FuncMap,
-    imports: &Imports,
-    class_map: &ClassMap,
-    module_cache: &mut Option<&mut ModuleCache>,
-    module_path: Option<&Path>,
-    f: F,
-) -> Option<R>
-where
-    F: FnOnce(
-        &ClassInfo,
-        &str,
-        &FuncMap,
-        &Imports,
-        &ClassMap,
-        Option<&Path>,
-        &mut Option<&mut ModuleCache>,
-    ) -> R,
-{
-    match &class_ref.module {
-        Some(module_name) => {
-            let module = {
-                let (Some(cache), Some(cur_path)) = (module_cache.as_deref_mut(), module_path)
-                else {
-                    return None;
-                };
-                cache.get_module(module_name, cur_path)?
-            };
-            let class_info = module.class_map.get(&class_ref.name)?;
-            Some(f(
-                class_info,
-                &module.source,
-                &module.func_map,
-                &module.imports,
-                &module.class_map,
-                Some(module.path.as_path()),
-                module_cache,
-            ))
-        }
-        None => {
-            let class_info = class_map.get(&class_ref.name)?;
-            Some(f(
-                class_info,
-                source,
-                func_map,
-                imports,
-                class_map,
-                module_path,
-                module_cache,
-            ))
-        }
-    }
-}
-
-fn resolve_module_path(
-    module: &str,
-    current_file: &Path,
-    project_root: Option<&Path>,
-) -> Option<PathBuf> {
-    let mut search_roots: Vec<PathBuf> = Vec::new();
-
-    if let Some(parent) = current_file.parent() {
-        search_roots.push(parent.to_path_buf());
-    }
-    if let Some(prj) = project_root {
-        search_roots.push(prj.to_path_buf());
-        let src_dir = prj.join("src");
-        if src_dir.exists() {
-            search_roots.push(src_dir);
-        }
-    }
-
-    // Search for virtual environment markers in PATH.
-    if let Ok(path_var) = std::env::var("PATH") {
-        for entry in path_var.split(':') {
-            if !entry.contains(".venv") {
-                continue;
-            }
-            let mut p = PathBuf::from(entry);
-            while let Some(parent) = p.parent() {
-                if let Some(name) = parent.file_name()
-                    && name.to_string_lossy().contains(".venv")
-                {
-                    let venv_dir = parent.to_path_buf();
-                    // parent of .venv might be the project root
-                    if let Some(parent_parent) = venv_dir.parent() {
-                        search_roots.push(parent_parent.to_path_buf());
-                    }
-                    // site-packages paths
-                    let lib_dir = venv_dir.join("lib");
-                    if lib_dir.exists()
-                        && let Ok(entries) = fs::read_dir(&lib_dir)
-                    {
-                        for entry in entries.flatten() {
-                            let fname = entry.file_name();
-                            if fname.to_string_lossy().starts_with("python") {
-                                let sp = entry.path().join("site-packages");
-                                if sp.exists() {
-                                    search_roots.push(sp);
-                                }
-                            }
-                        }
-                    }
-                    break;
-                }
-                p = parent.to_path_buf();
-            }
-        }
-    }
-
-    // Convert module name to path components.
-    let parts: Vec<&str> = module.split('.').collect();
-    for root in search_roots {
-        let mut base = root.clone();
-        for part in &parts {
-            base.push(part);
-        }
-        let file_candidate = base.with_extension("py");
-        if file_candidate.exists() {
-            return Some(file_candidate);
-        }
-        let init_candidate = base.join("__init__.py");
-        if init_candidate.exists() {
-            return Some(init_candidate);
-        }
-        // Heuristic: if root already points at the top-level package (e.g., root ends with parts[0]),
-        // try resolving without repeating the first component to avoid example_python/example_python duplication.
-        if let Some(root_name) = root.file_name()
-            && root_name
-                == parts
-                    .first()
-                    .map(std::ffi::OsStr::new)
-                    .unwrap_or_else(|| std::ffi::OsStr::new(""))
-            && parts.len() > 1
-        {
-            let mut base = root.clone();
-            for part in parts.iter().skip(1) {
-                base.push(part);
-            }
-            let file_candidate = base.with_extension("py");
-            if file_candidate.exists() {
-                return Some(file_candidate);
-            }
-            let init_candidate = base.join("__init__.py");
-            if init_candidate.exists() {
-                return Some(init_candidate);
-            }
-        }
-    }
-    None
-}
-
 pub fn analyze_source(source: &str) -> Analysis {
-    analyze_source_internal(source, None, None)
+    if let Ok(cwd) = std::env::current_dir() {
+        let anchor = cwd.join("__memory__.py");
+        let mut cache = ModuleCache::new(&anchor);
+        analyze_source_internal(source, Some(&anchor), Some(&mut cache))
+    } else {
+        analyze_source_internal(source, None, None)
+    }
 }
 
 /// Analyze in-memory source but anchored at a file path so imports can resolve.
@@ -526,6 +287,7 @@ fn analyze_source_internal<'a>(
                 &mut analysis,
                 module_cache,
                 current_path,
+                None,
             );
         }
         Err(err) => {
@@ -545,128 +307,6 @@ fn analyze_source_internal<'a>(
     analysis
 }
 
-fn collect_function_defs(body: &[Stmt], func_map: &mut FuncMap) {
-    for stmt in body {
-        if let Stmt::FunctionDef(func) = stmt {
-            func_map.insert(
-                func.name.clone(),
-                FunctionInfo {
-                    args: func.args.clone(),
-                    body: func.body.clone(),
-                    returns: func.returns.clone(),
-                },
-            );
-        }
-    }
-}
-
-struct ClassDefInfo {
-    forward: Option<FunctionInfo>,
-    methods: HashMap<Identifier, FunctionInfo>,
-    base_names: Vec<Identifier>,
-    direct_torch: bool,
-}
-
-fn is_torch_nn_module_base(expr: &Expr, imports: &Imports) -> bool {
-    let Expr::Attribute(attr) = expr else {
-        return false;
-    };
-    if attr.attr.as_str() != "Module" {
-        return false;
-    }
-    match attr.value.as_ref() {
-        Expr::Attribute(nn_attr) if nn_attr.attr.as_str() == "nn" => {
-            if let Expr::Name(torch_name) = nn_attr.value.as_ref() {
-                return imports.torch_aliases.contains(&torch_name.id);
-            }
-            false
-        }
-        Expr::Name(nn_name) => imports
-            .module_aliases
-            .get(&nn_name.id)
-            .map(|module| module == "torch.nn")
-            .unwrap_or(false),
-        _ => false,
-    }
-}
-
-fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
-    let mut defs: HashMap<Identifier, ClassDefInfo> = HashMap::new();
-    for stmt in body {
-        if let Stmt::ClassDef(class_def) = stmt {
-            let mut methods = HashMap::new();
-            let mut forward = None;
-            for stmt in class_def.body.iter() {
-                if let Stmt::FunctionDef(func) = stmt {
-                    let info = FunctionInfo {
-                        args: func.args.clone(),
-                        body: func.body.clone(),
-                        returns: func.returns.clone(),
-                    };
-                    if func.name.as_str() == "forward" {
-                        forward = Some(info.clone());
-                    }
-                    methods.insert(func.name.clone(), info);
-                }
-            }
-            let base_names = class_def
-                .bases
-                .iter()
-                .filter_map(|base| match base {
-                    Expr::Name(name) => Some(name.id.clone()),
-                    _ => None,
-                })
-                .collect();
-            let direct_torch = class_def
-                .bases
-                .iter()
-                .any(|base| is_torch_nn_module_base(base, imports));
-            defs.insert(
-                class_def.name.clone(),
-                ClassDefInfo {
-                    forward,
-                    methods,
-                    base_names,
-                    direct_torch,
-                },
-            );
-        }
-    }
-
-    let mut is_torch: HashMap<Identifier, bool> = defs
-        .iter()
-        .map(|(name, info)| (name.clone(), info.direct_torch))
-        .collect();
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for (name, info) in defs.iter() {
-            if !is_torch.get(name).copied().unwrap_or(false)
-                && info
-                    .base_names
-                    .iter()
-                    .any(|base| is_torch.get(base).copied().unwrap_or(false))
-            {
-                is_torch.insert(name.clone(), true);
-                changed = true;
-            }
-        }
-    }
-
-    let mut class_map = HashMap::new();
-    for (name, info) in defs {
-        class_map.insert(
-            name.clone(),
-            ClassInfo {
-                is_torch_module: is_torch.get(&name).copied().unwrap_or(false),
-                forward: info.forward,
-                methods: info.methods,
-            },
-        );
-    }
-    class_map
-}
-
 /// Iterate over the function and classes of a module `body`.
 ///
 /// The base case is a function, where shape inference is run. For classes,
@@ -680,6 +320,7 @@ fn analyze_function_bodies(
     analysis: &mut Analysis,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
+    current_class_ref: Option<ClassRef>,
 ) {
     for stmt in body {
         match stmt {
@@ -694,6 +335,7 @@ fn analyze_function_bodies(
                     &mut Vec::new(),
                     module_cache.as_deref_mut(),
                     module_path,
+                    current_class_ref.as_ref(),
                 );
                 analysis.diagnostics.append(&mut func_analysis.diagnostics);
                 analysis
@@ -709,6 +351,10 @@ fn analyze_function_bodies(
                 analysis,
                 module_cache.as_deref_mut(),
                 module_path,
+                Some(ClassRef {
+                    name: class_def.name.clone(),
+                    module: None,
+                }),
             ),
             _ => {}
         }
@@ -725,7 +371,21 @@ fn analyze_function(
     call_stack: &mut Vec<Identifier>,
     module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
+    current_class_ref: Option<&ClassRef>,
 ) -> Analysis {
+    let mut initial_vars = HashMap::new();
+    if let Some(class_ref) = current_class_ref
+        && method_param_offset(args) == 1
+    {
+        initial_vars.insert(
+            Identifier::from("self"),
+            VarState {
+                annotated: None,
+                inferred: None,
+                class_ref: Some(class_ref.clone()),
+            },
+        );
+    }
     let (diagnostics, hover_entries, _) = simulate_function(
         args,
         body,
@@ -734,7 +394,7 @@ fn analyze_function(
         imports,
         class_map,
         call_stack,
-        HashMap::new(),
+        initial_vars,
         true,
         module_cache,
         module_path,
@@ -744,6 +404,37 @@ fn analyze_function(
         diagnostics,
         hover_entries,
     }
+}
+
+fn expr_has_unbound_self(expr: &Expr, vars: &HashMap<Identifier, VarState>) -> bool {
+    match expr {
+        Expr::Name(name) => name.id.as_str() == "self" && !vars.contains_key(&name.id),
+        Expr::Attribute(attr) => expr_has_unbound_self(attr.value.as_ref(), vars),
+        _ => false,
+    }
+}
+
+fn report_unbound_self_diagnostic(
+    expr: &Expr,
+    vars: &HashMap<Identifier, VarState>,
+    diagnostics: &mut Vec<Diagnostic>,
+    source: &str,
+) -> bool {
+    if !expr_has_unbound_self(expr, vars) {
+        return false;
+    }
+    diagnostics.push(Diagnostic {
+        range: text_range_to_lsp(expr_text_range(expr), source),
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: None,
+        code_description: None,
+        source: Some("shapels".into()),
+        message: "Unknown `self`: method must declare `self` as its first parameter".into(),
+        related_information: None,
+        tags: None,
+        data: None,
+    });
+    true
 }
 
 /// Initializes inputs of a function and wraps around [`simulate_block`]
@@ -775,6 +466,9 @@ fn simulate_function(
         imports,
         class_map,
     );
+    for (name, state) in initial_vars {
+        vars.entry(name).or_insert(state);
+    }
 
     let mut return_value = ReturnValue::default();
 
@@ -932,10 +626,13 @@ fn simulate_block(
                             hover_entries.push((range, HoverInfo { shape: Some(shape) }));
                         }
                     } else if let Some(val) = &assign.value
-                        && let Some(class_ref) = class_ref_from_constructor_call(
+                        && let Some(class_ref) = class_ref_from_expr(
                             val,
-                            class_map,
+                            vars,
+                            source,
+                            func_map,
                             imports,
+                            class_map,
                             module_cache.as_deref_mut(),
                             module_path,
                         )
@@ -1033,10 +730,13 @@ fn simulate_block(
                         if record_hovers {
                             hover_entries.push((range, HoverInfo { shape: Some(shape) }));
                         }
-                    } else if let Some(class_ref) = class_ref_from_constructor_call(
+                    } else if let Some(class_ref) = class_ref_from_expr(
                         &assign.value,
-                        class_map,
+                        vars,
+                        source,
+                        func_map,
                         imports,
+                        class_map,
                         module_cache.as_deref_mut(),
                         module_path,
                     ) {
@@ -1398,26 +1098,36 @@ fn infer_expr_shape(
             })
         }
         Expr::Call(call) => {
+            if report_unbound_self_diagnostic(call.func.as_ref(), vars, diagnostics, source) {
+                return None;
+            }
+            if let Some(class_ref) = class_ref_from_expr(
+                call.func.as_ref(),
+                vars,
+                source,
+                func_map,
+                imports,
+                class_map,
+                module_cache.as_deref_mut(),
+                module_path,
+            ) && let Some(ret) = infer_class_call_return(
+                call,
+                &class_ref,
+                vars,
+                func_map,
+                imports,
+                class_map,
+                call_stack,
+                diagnostics,
+                hover_entries,
+                record_hovers,
+                source,
+                module_cache.as_deref_mut(),
+                module_path,
+            ) {
+                return ret.first().cloned();
+            }
             if let Expr::Name(func_name) = call.func.as_ref() {
-                if let Some(class_ref) = vars.get(&func_name.id).and_then(|v| v.class_ref.as_ref())
-                    && let Some(ret) = infer_class_call_return(
-                        call,
-                        class_ref,
-                        vars,
-                        func_map,
-                        imports,
-                        class_map,
-                        call_stack,
-                        diagnostics,
-                        hover_entries,
-                        record_hovers,
-                        source,
-                        module_cache.as_deref_mut(),
-                        module_path,
-                    )
-                {
-                    return ret.first().cloned();
-                }
                 let torchop_shape = torch_op_to_shape(
                     vars,
                     func_map,
@@ -1464,6 +1174,7 @@ fn infer_expr_shape(
                         source,
                         module_cache.as_deref_mut(),
                         Some(module.path.as_path()),
+                        None,
                         0,
                         false,
                     )
@@ -1490,6 +1201,7 @@ fn infer_expr_shape(
                         source,
                         module_cache.as_deref_mut(),
                         module_path,
+                        None,
                         0,
                         false,
                     )
@@ -1500,26 +1212,31 @@ fn infer_expr_shape(
             // methods are functions with attributes
             if let Expr::Attribute(attr) = call.func.as_ref() {
                 let attr_name: &str = attr.attr.as_ref();
-                if let Expr::Name(base_name) = attr.value.as_ref()
-                    && let Some(class_ref) =
-                        vars.get(&base_name.id).and_then(|v| v.class_ref.as_ref())
-                    && let Some(ret) = infer_class_method_call_return(
-                        call,
-                        class_ref,
-                        &attr.attr,
-                        vars,
-                        func_map,
-                        imports,
-                        class_map,
-                        call_stack,
-                        diagnostics,
-                        hover_entries,
-                        record_hovers,
-                        source,
-                        module_cache.as_deref_mut(),
-                        module_path,
-                    )
-                {
+                if let Some(class_ref) = class_ref_from_expr(
+                    attr.value.as_ref(),
+                    vars,
+                    source,
+                    func_map,
+                    imports,
+                    class_map,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) && let Some(ret) = infer_class_method_call_return(
+                    call,
+                    &class_ref,
+                    &attr.attr,
+                    vars,
+                    func_map,
+                    imports,
+                    class_map,
+                    call_stack,
+                    diagnostics,
+                    hover_entries,
+                    record_hovers,
+                    source,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) {
                     return ret.first().cloned();
                 }
                 if let Expr::Name(module_ident) = attr.value.as_ref()
@@ -1548,6 +1265,7 @@ fn infer_expr_shape(
                         source,
                         module_cache.as_deref_mut(),
                         Some(module.path.as_path()),
+                        None,
                         0,
                         false,
                     )
@@ -1597,6 +1315,9 @@ fn infer_expr_shape(
         ),
         // attributes of a tensor, not a method!
         Expr::Attribute(attr) => {
+            if report_unbound_self_diagnostic(expr, vars, diagnostics, source) {
+                return None;
+            }
             let attr_name: &str = attr.attr.as_ref();
             if attr_name == "T" {
                 let base_hint =
@@ -1658,6 +1379,9 @@ fn infer_expr_shape(
             None
         }
         Expr::Name(expr_name) => {
+            if report_unbound_self_diagnostic(expr, vars, diagnostics, source) {
+                return None;
+            }
             let shape = vars
                 .get(&expr_name.id)
                 .and_then(|v| v.annotated.clone().or_else(|| v.inferred.clone()));
@@ -1678,9 +1402,9 @@ fn infer_expr_shape(
 /// incorrect.
 fn torch_op_to_shape(
     vars: &HashMap<Identifier, VarState>,
-    func_map: &HashMap<Identifier, FunctionInfo>,
+    func_map: &FuncMap,
     imports: &Imports,
-    class_map: &HashMap<Identifier, ClassInfo>,
+    class_map: &ClassMap,
     call_stack: &mut Vec<Identifier>,
     diagnostics: &mut Vec<Diagnostic>,
     hover_entries: &mut Vec<(Range, HoverInfo)>,
@@ -2067,86 +1791,6 @@ fn infer_tuple_elements(
     }
 }
 
-fn method_param_offset(args: &Arguments) -> usize {
-    match args.args.first() {
-        Some(param) if param.def.arg.as_str() == "self" => 1,
-        _ => 0,
-    }
-}
-
-fn class_ref_from_constructor_call(
-    call_expr: &Expr,
-    class_map: &ClassMap,
-    imports: &Imports,
-    mut module_cache: Option<&mut ModuleCache>,
-    module_path: Option<&Path>,
-) -> Option<ClassRef> {
-    let Expr::Call(call) = call_expr else {
-        return None;
-    };
-    match call.func.as_ref() {
-        Expr::Name(name) => {
-            if class_map.contains_key(&name.id) {
-                return Some(ClassRef {
-                    name: name.id.clone(),
-                    module: None,
-                });
-            }
-            if let Some((module_name, original)) = imports.from_imports.get(&name.id)
-                && module_name != "torch"
-                && !module_name.starts_with("torch.")
-                && let (Some(cache), Some(cur_path)) = (module_cache.as_deref_mut(), module_path)
-                && let Some(module) = cache.get_module(module_name, cur_path)
-                && module.class_map.contains_key(original)
-            {
-                return Some(ClassRef {
-                    name: original.clone(),
-                    module: Some(module_name.to_string()),
-                });
-            }
-        }
-        Expr::Attribute(attr) => {
-            if let Expr::Name(module_ident) = attr.value.as_ref()
-                && let Some(module_name) = imports.module_aliases.get(&module_ident.id)
-                && module_name != "torch"
-                && !module_name.starts_with("torch.")
-                && let (Some(cache), Some(cur_path)) = (module_cache, module_path)
-                && let Some(module) = cache.get_module(module_name, cur_path)
-                && module.class_map.contains_key(&attr.attr)
-            {
-                return Some(ClassRef {
-                    name: attr.attr.clone(),
-                    module: Some(module_name.to_string()),
-                });
-            }
-        }
-        _ => {}
-    }
-    None
-}
-
-fn class_ref_from_annotation(
-    ann: &Expr,
-    imports: &Imports,
-    class_map: &ClassMap,
-) -> Option<ClassRef> {
-    if let Expr::Name(name) = ann {
-        if class_map.contains_key(&name.id) {
-            return Some(ClassRef {
-                name: name.id.clone(),
-                module: None,
-            });
-        }
-        if let Some((module_name, original)) = imports.from_imports.get(&name.id) {
-            return Some(ClassRef {
-                name: original.clone(),
-                module: Some(module_name.clone()),
-            });
-        }
-    }
-    None
-}
-
 fn union_members<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
     if let Expr::BinOp(ExprBinOp {
         left, op, right, ..
@@ -2235,6 +1879,7 @@ fn infer_call_return_from_info(
     source: &str,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
+    callee_self_class_ref: Option<&ClassRef>,
     param_offset: usize,
     emit_body_diagnostics: bool,
 ) -> Option<ReturnValue> {
@@ -2301,9 +1946,16 @@ fn infer_call_return_from_info(
                         class_ref: None,
                     },
                 );
-            } else if let Expr::Name(name) = arg_expr
-                && let Some(class_ref) = vars.get(&name.id).and_then(|v| v.class_ref.clone())
-            {
+            } else if let Some(class_ref) = class_ref_from_expr(
+                arg_expr,
+                vars,
+                source,
+                func_map,
+                imports,
+                class_map,
+                module_cache.as_deref_mut(),
+                module_path,
+            ) {
                 arg_shapes.insert(
                     param.def.arg.clone(),
                     VarState {
@@ -2314,6 +1966,16 @@ fn infer_call_return_from_info(
                 );
             }
         }
+    }
+    if let Some(self_class_ref) = callee_self_class_ref {
+        arg_shapes.insert(
+            Identifier::from("self"),
+            VarState {
+                annotated: None,
+                inferred: None,
+                class_ref: Some(self_class_ref.clone()),
+            },
+        );
     }
     if let Some(ret_ann) = callee_info.returns.as_deref() {
         let annotated_return = if let Some(ret_shape) = parse_shape_annotation(ret_ann) {
@@ -2326,7 +1988,7 @@ fn infer_call_return_from_info(
             shape_union.map(|shape| ReturnValue::from_shape(Some(shape)))
         };
         if let Some(ret) = annotated_return {
-            if emit_body_diagnostics {
+            if emit_body_diagnostics || record_hovers {
                 call_stack.push(callee_name.clone());
                 let (mut diag, mut hovers, _) = simulate_function(
                     callee_info.args.as_ref(),
@@ -2341,7 +2003,9 @@ fn infer_call_return_from_info(
                     module_cache.as_deref_mut(),
                     module_path,
                 );
-                diagnostics.append(&mut diag);
+                if emit_body_diagnostics {
+                    diagnostics.append(&mut diag);
+                }
                 if record_hovers {
                     hover_entries.append(&mut hovers);
                 }
@@ -2360,23 +2024,30 @@ fn infer_call_return_from_info(
         callee_class_map,
         call_stack,
         arg_shapes,
-        false,
+        record_hovers,
         module_cache,
         module_path,
     );
     if emit_body_diagnostics {
         diagnostics.append(&mut diag);
-        if record_hovers {
-            hover_entries.append(&mut hovers);
-        }
+    }
+    if record_hovers {
+        hover_entries.append(&mut hovers);
     }
     call_stack.pop();
     Some(ret_value)
 }
 
-fn infer_class_call_return(
+#[derive(Clone, Copy)]
+enum ClassCallable<'a> {
+    Forward,
+    Method(&'a Identifier),
+}
+
+fn infer_class_member_call_return(
     call: &ExprCall<TextRange>,
     class_ref: &ClassRef,
+    callable: ClassCallable<'_>,
     vars: &HashMap<Identifier, VarState>,
     func_map: &FuncMap,
     imports: &Imports,
@@ -2389,6 +2060,12 @@ fn infer_class_call_return(
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<ReturnValue> {
+    let callee_name = match callable {
+        ClassCallable::Forward => class_ref.name.clone(),
+        ClassCallable::Method(method_name) => {
+            Identifier::from(format!("{}::{}", class_ref.name, method_name))
+        }
+    };
     with_class_info(
         class_ref,
         source,
@@ -2404,15 +2081,20 @@ fn infer_class_call_return(
          callee_class_map,
          callee_path,
          module_cache| {
-            if !class_info.is_torch_module {
-                return None;
-            }
-            let forward = class_info.forward.as_ref()?;
-            let param_offset = method_param_offset(&forward.args);
+            let callee_info = match callable {
+                ClassCallable::Forward => {
+                    if !class_info.is_torch_module {
+                        return None;
+                    }
+                    class_info.forward.as_ref()?
+                }
+                ClassCallable::Method(method_name) => class_info.methods.get(method_name)?,
+            };
+            let param_offset = method_param_offset(&callee_info.args);
             infer_call_return_from_info(
                 call,
-                &class_ref.name,
-                forward,
+                &callee_name,
+                callee_info,
                 callee_source,
                 callee_func_map,
                 callee_imports,
@@ -2428,12 +2110,46 @@ fn infer_class_call_return(
                 source,
                 module_cache.as_deref_mut(),
                 callee_path,
+                Some(class_ref),
                 param_offset,
                 false,
             )
         },
     )
-    .and_then(|ret| ret)
+    .flatten()
+}
+
+fn infer_class_call_return(
+    call: &ExprCall<TextRange>,
+    class_ref: &ClassRef,
+    vars: &HashMap<Identifier, VarState>,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    call_stack: &mut Vec<Identifier>,
+    diagnostics: &mut Vec<Diagnostic>,
+    hover_entries: &mut Vec<(Range, HoverInfo)>,
+    record_hovers: bool,
+    source: &str,
+    module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ReturnValue> {
+    infer_class_member_call_return(
+        call,
+        class_ref,
+        ClassCallable::Forward,
+        vars,
+        func_map,
+        imports,
+        class_map,
+        call_stack,
+        diagnostics,
+        hover_entries,
+        record_hovers,
+        source,
+        module_cache,
+        module_path,
+    )
 }
 
 fn infer_class_method_call_return(
@@ -2449,52 +2165,25 @@ fn infer_class_method_call_return(
     hover_entries: &mut Vec<(Range, HoverInfo)>,
     record_hovers: bool,
     source: &str,
-    mut module_cache: Option<&mut ModuleCache>,
+    module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<ReturnValue> {
-    let callee_name = Identifier::from(format!("{}::{}", class_ref.name, method_name));
-    with_class_info(
+    infer_class_member_call_return(
+        call,
         class_ref,
-        source,
+        ClassCallable::Method(method_name),
+        vars,
         func_map,
         imports,
         class_map,
-        &mut module_cache,
+        call_stack,
+        diagnostics,
+        hover_entries,
+        record_hovers,
+        source,
+        module_cache,
         module_path,
-        |class_info,
-         callee_source,
-         callee_func_map,
-         callee_imports,
-         callee_class_map,
-         callee_path,
-         module_cache| {
-            let method_info = class_info.methods.get(method_name)?;
-            let param_offset = method_param_offset(&method_info.args);
-            infer_call_return_from_info(
-                call,
-                &callee_name,
-                method_info,
-                callee_source,
-                callee_func_map,
-                callee_imports,
-                callee_class_map,
-                vars,
-                func_map,
-                imports,
-                class_map,
-                call_stack,
-                diagnostics,
-                hover_entries,
-                record_hovers,
-                source,
-                module_cache.as_deref_mut(),
-                callee_path,
-                param_offset,
-                false,
-            )
-        },
     )
-    .and_then(|ret| ret)
 }
 
 fn infer_defined_call_return(
@@ -2511,24 +2200,36 @@ fn infer_defined_call_return(
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<ReturnValue> {
+    if report_unbound_self_diagnostic(call.func.as_ref(), vars, diagnostics, source) {
+        return None;
+    }
+    if let Some(class_ref) = class_ref_from_expr(
+        call.func.as_ref(),
+        vars,
+        source,
+        func_map,
+        imports,
+        class_map,
+        module_cache.as_deref_mut(),
+        module_path,
+    ) {
+        return infer_class_call_return(
+            call,
+            &class_ref,
+            vars,
+            func_map,
+            imports,
+            class_map,
+            call_stack,
+            diagnostics,
+            hover_entries,
+            record_hovers,
+            source,
+            module_cache.as_deref_mut(),
+            module_path,
+        );
+    }
     if let Expr::Name(func_name) = call.func.as_ref() {
-        if let Some(class_ref) = vars.get(&func_name.id).and_then(|v| v.class_ref.as_ref()) {
-            return infer_class_call_return(
-                call,
-                class_ref,
-                vars,
-                func_map,
-                imports,
-                class_map,
-                call_stack,
-                diagnostics,
-                hover_entries,
-                record_hovers,
-                source,
-                module_cache.as_deref_mut(),
-                module_path,
-            );
-        }
         if let Some((module_name, original)) = imports.from_imports.get(&func_name.id)
             && let (Some(cache), Some(cur_path)) = (module_cache.as_deref_mut(), module_path)
             && let Some(module) = cache.get_module(module_name, cur_path)
@@ -2553,6 +2254,7 @@ fn infer_defined_call_return(
                 source,
                 module_cache.as_deref_mut(),
                 Some(module.path.as_path()),
+                None,
                 0,
                 false,
             );
@@ -2577,18 +2279,27 @@ fn infer_defined_call_return(
                 source,
                 module_cache.as_deref_mut(),
                 module_path,
+                None,
                 0,
                 false,
             );
         }
     }
     if let Expr::Attribute(attr) = call.func.as_ref()
-        && let Expr::Name(base_name) = attr.value.as_ref()
-        && let Some(class_ref) = vars.get(&base_name.id).and_then(|v| v.class_ref.as_ref())
+        && let Some(class_ref) = class_ref_from_expr(
+            attr.value.as_ref(),
+            vars,
+            source,
+            func_map,
+            imports,
+            class_map,
+            module_cache.as_deref_mut(),
+            module_path,
+        )
     {
         return infer_class_method_call_return(
             call,
-            class_ref,
+            &class_ref,
             &attr.attr,
             vars,
             func_map,
@@ -2630,6 +2341,7 @@ fn infer_defined_call_return(
             source,
             module_cache,
             Some(module.path.as_path()),
+            None,
             0,
             false,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1964,14 +1964,24 @@ fn infer_call_return_from_info(
         }
     }
     if let Some(self_class_ref) = callee_self_class_ref {
-        arg_shapes.insert(
-            Identifier::from("self"),
-            VarState {
-                annotated: None,
-                inferred: None,
-                class_ref: Some(self_class_ref.clone()),
-            },
-        );
+        // Only bind `self` when the callee signature actually declares `self` as the first parameter.
+        let has_leading_self = param_offset > 0
+            && callee_info
+                .args
+                .args
+                .first()
+                .map(|param| param.def.arg.as_str() == "self")
+                .unwrap_or(false);
+        if has_leading_self {
+            arg_shapes.insert(
+                Identifier::from("self"),
+                VarState {
+                    annotated: None,
+                    inferred: None,
+                    class_ref: Some(self_class_ref.clone()),
+                },
+            );
+        }
     }
     if let Some(ret_ann) = callee_info.returns.as_deref() {
         let annotated_return = if let Some(ret_shape) = parse_shape_annotation(ret_ann) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,13 +192,7 @@ fn normalize_return_annotations<'a>(source: &'a str) -> Cow<'a, str> {
 }
 
 pub fn analyze_source(source: &str) -> Analysis {
-    if let Ok(cwd) = std::env::current_dir() {
-        let anchor = cwd.join("__memory__.py");
-        let mut cache = ModuleCache::new(&anchor);
-        analyze_source_internal(source, Some(&anchor), Some(&mut cache))
-    } else {
-        analyze_source_internal(source, None, None)
-    }
+    analyze_source_internal(source, None, None)
 }
 
 /// Analyze in-memory source but anchored at a file path so imports can resolve.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1490,7 +1490,7 @@ pub(crate) fn infer_expr_shape(
                 func_map,
                 imports,
                 class_map,
-                module_cache.as_deref_mut(),
+                module_cache,
                 module_path,
             )
             .and_then(|state| state_shape(&state).cloned());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,10 @@ use crate::infer::{
     infer_repeat, infer_repeat_interleave, infer_squeeze, infer_to, infer_unsqueeze,
     infer_view_like, shape_dims_equal,
 };
+pub use crate::module_resolution::ModuleCache;
 use crate::module_resolution::{
-    ClassMap, ClassRef, FuncMap, FunctionInfo, ModuleCache, class_ref_from_annotation,
-    class_ref_from_expr, collect_class_defs, collect_function_defs, method_param_offset,
-    with_class_info,
+    ClassMap, ClassRef, FuncMap, FunctionInfo, class_ref_from_annotation, class_ref_from_expr,
+    collect_class_defs, collect_function_defs, method_param_offset, with_class_info,
 };
 pub use crate::op_groups::AGGR_ALIASES;
 use crate::op_groups::{BroadcastOp, Imports, TORCH_DTYPES, TorchOp, collect_imports};
@@ -192,22 +192,37 @@ fn normalize_return_annotations<'a>(source: &'a str) -> Cow<'a, str> {
 }
 
 pub fn analyze_source(source: &str) -> Analysis {
-    analyze_source_internal(source, None, None)
+    let mut cache = ModuleCache::new();
+    analyze_source_with_cache(source, &mut cache)
+}
+
+pub fn analyze_source_with_cache(source: &str, module_cache: &mut ModuleCache) -> Analysis {
+    analyze_source_internal(source, None, Some(module_cache))
 }
 
 /// Analyze in-memory source but anchored at a file path so imports can resolve.
 pub fn analyze_source_at_path(source: &str, path: &Path) -> Analysis {
-    let mut cache = ModuleCache::new(path);
-    analyze_source_internal(source, Some(path), Some(&mut cache))
+    let mut cache = ModuleCache::new();
+    analyze_source_at_path_with_cache(source, path, &mut cache)
+}
+
+pub fn analyze_source_at_path_with_cache(
+    source: &str,
+    path: &Path,
+    module_cache: &mut ModuleCache,
+) -> Analysis {
+    analyze_source_internal(source, Some(path), Some(module_cache))
 }
 
 /// Analyze a python file with module resolution enabled.
 pub fn analyze_file(path: &Path) -> Analysis {
+    let mut cache = ModuleCache::new();
+    analyze_file_with_cache(path, &mut cache)
+}
+
+pub fn analyze_file_with_cache(path: &Path, module_cache: &mut ModuleCache) -> Analysis {
     match fs::read_to_string(path) {
-        Ok(src) => {
-            let mut cache = ModuleCache::new(path);
-            analyze_source_internal(&src, Some(path), Some(&mut cache))
-        }
+        Ok(src) => analyze_source_internal(&src, Some(path), Some(module_cache)),
         Err(err) => Analysis {
             diagnostics: vec![Diagnostic {
                 range: default_range(),
@@ -238,11 +253,12 @@ fn analyze_source_internal<'a>(
         .unwrap_or_else(|| "<memory>".to_string());
     match Suite::parse(source, &parse_name) {
         Ok(module) => {
-            let imports = collect_imports(
-                &module,
-                current_path,
-                module_cache.as_deref().and_then(|c| c.project_root()),
-            );
+            let project_root = current_path.and_then(|path| {
+                module_cache
+                    .as_deref_mut()
+                    .and_then(|cache| cache.project_root_for(path))
+            });
+            let imports = collect_imports(&module, current_path, project_root.as_deref());
             // collect function definitions first
             let mut func_map: FuncMap = HashMap::new();
             collect_function_defs(&module, &mut func_map);
@@ -1171,7 +1187,7 @@ fn infer_expr_shape(
                         record_hovers,
                         source,
                         module_cache.as_deref_mut(),
-                        Some(module.path.as_path()),
+                        Some(module.file_path.as_path()),
                         None,
                         0,
                         false,
@@ -1262,7 +1278,7 @@ fn infer_expr_shape(
                         record_hovers,
                         source,
                         module_cache.as_deref_mut(),
-                        Some(module.path.as_path()),
+                        Some(module.file_path.as_path()),
                         None,
                         0,
                         false,
@@ -2262,7 +2278,7 @@ fn infer_defined_call_return(
                 record_hovers,
                 source,
                 module_cache.as_deref_mut(),
-                Some(module.path.as_path()),
+                Some(module.file_path.as_path()),
                 None,
                 0,
                 false,
@@ -2349,7 +2365,7 @@ fn infer_defined_call_return(
             record_hovers,
             source,
             module_cache,
-            Some(module.path.as_path()),
+            Some(module.file_path.as_path()),
             None,
             0,
             false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ use lsp_types::{
     notification::PublishDiagnostics,
     request::{DocumentDiagnosticRequest, HoverRequest},
 };
-use shapels::{analyze_source, analyze_source_at_path};
+#[cfg(test)]
+use shapels::analyze_source;
+use shapels::{ModuleCache, analyze_source_at_path_with_cache, analyze_source_with_cache};
 use std::collections::HashMap;
 
 mod cli;
@@ -40,6 +42,7 @@ fn main() {
     let _init_params = connection.initialize(server_capabilities).unwrap();
 
     let mut documents: HashMap<Url, String> = HashMap::new();
+    let mut module_cache = ModuleCache::new();
 
     for msg in &connection.receiver {
         match msg {
@@ -47,7 +50,7 @@ fn main() {
                 if connection.handle_shutdown(&req).unwrap() {
                     break;
                 }
-                handle_request(&req, &connection, &mut documents);
+                handle_request(&req, &connection, &mut documents, &mut module_cache);
             }
             Message::Notification(notif) => {
                 match notif.method.as_str() {
@@ -57,8 +60,12 @@ fn main() {
                         >(notif.params.clone())
                         {
                             let uri = params.text_document.uri.clone();
-                            documents.insert(uri.clone(), params.text_document.text);
-                            publish_diagnostics(&connection, &documents, &uri);
+                            let text = params.text_document.text;
+                            if let Ok(path) = uri.to_file_path() {
+                                module_cache.update_file_source(&path, text.clone());
+                            }
+                            documents.insert(uri.clone(), text);
+                            publish_diagnostics(&connection, &documents, &uri, &mut module_cache);
                         }
                     }
                     "textDocument/didChange" => {
@@ -69,8 +76,11 @@ fn main() {
                         {
                             let uri = params.text_document.uri.clone();
                             // assuming full sync kind
+                            if let Ok(path) = uri.to_file_path() {
+                                module_cache.update_file_source(&path, first.text.clone());
+                            }
                             documents.insert(uri.clone(), first.text.clone());
-                            publish_diagnostics(&connection, &documents, &uri);
+                            publish_diagnostics(&connection, &documents, &uri, &mut module_cache);
                         }
                     }
                     _ => {}
@@ -83,7 +93,12 @@ fn main() {
     io_threads.join().expect("Failed to join IO threads");
 }
 
-fn handle_request(req: &Request, connection: &Connection, documents: &mut HashMap<Url, String>) {
+fn handle_request(
+    req: &Request,
+    connection: &Connection,
+    documents: &mut HashMap<Url, String>,
+    module_cache: &mut ModuleCache,
+) {
     match req.method.as_str() {
         <HoverRequest as lsp_types::request::Request>::METHOD => {
             let id = req.id.clone();
@@ -94,8 +109,8 @@ fn handle_request(req: &Request, connection: &Connection, documents: &mut HashMa
                 let analysis = uri
                     .to_file_path()
                     .ok()
-                    .map(|p| analyze_source_at_path(text, &p))
-                    .unwrap_or_else(|| analyze_source(text));
+                    .map(|p| analyze_source_at_path_with_cache(text, &p, module_cache))
+                    .unwrap_or_else(|| analyze_source_with_cache(text, module_cache));
                 analysis.hover(pos).and_then(|info| {
                     info.shape.as_ref().map(|shape| Hover {
                         contents: HoverContents::Markup(MarkupContent {
@@ -123,8 +138,12 @@ fn handle_request(req: &Request, connection: &Connection, documents: &mut HashMa
                 .map(|text| {
                     uri.to_file_path()
                         .ok()
-                        .map(|p| analyze_source_at_path(text, &p).diagnostics)
-                        .unwrap_or_else(|| analyze_source(text).diagnostics)
+                        .map(|p| {
+                            analyze_source_at_path_with_cache(text, &p, module_cache).diagnostics
+                        })
+                        .unwrap_or_else(|| {
+                            analyze_source_with_cache(text, module_cache).diagnostics
+                        })
                 })
                 .unwrap_or_default();
             let full = FullDocumentDiagnosticReport {
@@ -149,10 +168,22 @@ fn handle_request(req: &Request, connection: &Connection, documents: &mut HashMa
     }
 }
 
-fn publish_diagnostics(connection: &Connection, documents: &HashMap<Url, String>, uri: &Url) {
+fn publish_diagnostics(
+    connection: &Connection,
+    documents: &HashMap<Url, String>,
+    uri: &Url,
+    module_cache: &mut ModuleCache,
+) {
     let diagnostics = documents
         .get(uri)
-        .map(|text| analyze_source(text).diagnostics)
+        .map(|text| {
+            uri.to_file_path()
+                .ok()
+                .map(|path| {
+                    analyze_source_at_path_with_cache(text, &path, module_cache).diagnostics
+                })
+                .unwrap_or_else(|| analyze_source_with_cache(text, module_cache).diagnostics)
+        })
         .unwrap_or_default();
     let params = PublishDiagnosticsParams {
         uri: uri.clone(),

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -6,6 +6,7 @@ use rustpython_parser::ast::{Arguments, Expr, Identifier, Stmt, Suite};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 #[derive(Clone)]
 pub(crate) struct FunctionInfo {
@@ -25,14 +26,13 @@ pub(crate) struct ClassRef {
 #[derive(Clone)]
 pub(crate) struct ClassInfo {
     pub(crate) is_torch_module: bool,
-    pub(crate) init: Option<FunctionInfo>,
-    pub(crate) forward: Option<FunctionInfo>,
+    pub(crate) init_name: Option<Identifier>,
+    pub(crate) forward_name: Option<Identifier>,
     pub(crate) methods: HashMap<Identifier, FunctionInfo>,
 }
 
 pub(crate) type ClassMap = HashMap<Identifier, ClassInfo>;
 
-#[derive(Clone)]
 pub(crate) struct CachedModule {
     pub(crate) path: PathBuf,
     pub(crate) source: String,
@@ -42,7 +42,7 @@ pub(crate) struct CachedModule {
 }
 
 pub(crate) struct ModuleCache {
-    modules: HashMap<String, CachedModule>,
+    modules: HashMap<String, Rc<CachedModule>>,
     project_root: Option<PathBuf>,
 }
 
@@ -63,9 +63,9 @@ impl ModuleCache {
         &mut self,
         module_name: &str,
         current_file: &Path,
-    ) -> Option<CachedModule> {
+    ) -> Option<Rc<CachedModule>> {
         if let Some(cached) = self.modules.get(module_name) {
-            return Some(cached.clone());
+            return Some(Rc::clone(cached));
         }
         let path = resolve_module_path(module_name, current_file, self.project_root.as_deref())?;
         let source = fs::read_to_string(&path).ok()?;
@@ -76,14 +76,15 @@ impl ModuleCache {
         let mut func_map = FuncMap::new();
         collect_function_defs(&module, &mut func_map);
         let class_map = collect_class_defs(&module, &imports);
-        let cached = CachedModule {
+        let cached = Rc::new(CachedModule {
             path,
             source,
             func_map,
             imports,
             class_map,
-        };
-        self.modules.insert(module_name.to_string(), cached.clone());
+        });
+        self.modules
+            .insert(module_name.to_string(), Rc::clone(&cached));
         Some(cached)
     }
 }
@@ -111,8 +112,8 @@ pub(crate) fn collect_function_defs(body: &[Stmt], func_map: &mut FuncMap) {
 }
 
 struct ClassDefInfo {
-    init: Option<FunctionInfo>,
-    forward: Option<FunctionInfo>,
+    init_name: Option<Identifier>,
+    forward_name: Option<Identifier>,
     methods: HashMap<Identifier, FunctionInfo>,
     base_names: Vec<Identifier>,
     direct_torch: bool,
@@ -146,8 +147,8 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
     for stmt in body {
         if let Stmt::ClassDef(class_def) = stmt {
             let mut methods = HashMap::new();
-            let mut init = None;
-            let mut forward = None;
+            let mut init_name = None;
+            let mut forward_name = None;
             for stmt in &class_def.body {
                 if let Stmt::FunctionDef(func) = stmt {
                     let info = FunctionInfo {
@@ -156,10 +157,10 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
                         returns: func.returns.clone(),
                     };
                     if func.name.as_str() == "__init__" {
-                        init = Some(info.clone());
+                        init_name = Some(func.name.clone());
                     }
                     if func.name.as_str() == "forward" {
-                        forward = Some(info.clone());
+                        forward_name = Some(func.name.clone());
                     }
                     methods.insert(func.name.clone(), info);
                 }
@@ -179,8 +180,8 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
             defs.insert(
                 class_def.name.clone(),
                 ClassDefInfo {
-                    init,
-                    forward,
+                    init_name,
+                    forward_name,
                     methods,
                     base_names,
                     direct_torch,
@@ -215,13 +216,34 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
                 name.clone(),
                 ClassInfo {
                     is_torch_module: is_torch.get(&name).copied().unwrap_or(false),
-                    init: info.init,
-                    forward: info.forward,
+                    init_name: info.init_name,
+                    forward_name: info.forward_name,
                     methods: info.methods,
                 },
             )
         })
         .collect()
+}
+
+pub(crate) enum ResolvedClassRef<'a> {
+    Borrowed(&'a ClassRef),
+    Owned(ClassRef),
+}
+
+impl<'a> ResolvedClassRef<'a> {
+    pub(crate) fn as_ref(&self) -> &ClassRef {
+        match self {
+            Self::Borrowed(class_ref) => class_ref,
+            Self::Owned(class_ref) => class_ref,
+        }
+    }
+
+    pub(crate) fn into_owned(self) -> ClassRef {
+        match self {
+            Self::Borrowed(class_ref) => class_ref.clone(),
+            Self::Owned(class_ref) => class_ref,
+        }
+    }
 }
 
 pub(crate) fn with_class_info<R, F>(
@@ -302,16 +324,16 @@ pub(crate) fn class_ref_from_annotation(
     None
 }
 
-pub(crate) fn class_ref_from_expr(
+pub(crate) fn class_ref_from_expr<'a>(
     expr: &Expr,
-    vars: &HashMap<Identifier, VarState>,
+    vars: &'a HashMap<Identifier, VarState>,
     source: &str,
     func_map: &FuncMap,
     imports: &Imports,
     class_map: &ClassMap,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ClassRef> {
+) -> Option<ResolvedClassRef<'a>> {
     if let Some(class_ref) = class_ref_from_constructor_call(
         expr,
         class_map,
@@ -319,7 +341,7 @@ pub(crate) fn class_ref_from_expr(
         module_cache.as_deref_mut(),
         module_path,
     ) {
-        return Some(class_ref);
+        return Some(ResolvedClassRef::Owned(class_ref));
     }
     resolve_class_ref_expr(
         expr,
@@ -343,17 +365,15 @@ fn self_attr_name(expr: &Expr) -> Option<Identifier> {
     (name.id.as_str() == "self").then(|| attr.attr.clone())
 }
 
-fn collect_self_class_refs_from_init(
+fn find_self_class_ref_in_init(
     init: Option<&FunctionInfo>,
+    target_attr: &Identifier,
     class_map: &ClassMap,
     imports: &Imports,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> HashMap<Identifier, ClassRef> {
-    let mut self_attrs = HashMap::new();
-    let Some(init) = init else {
-        return self_attrs;
-    };
+) -> Option<ClassRef> {
+    let init = init?;
 
     for stmt in &init.body {
         let maybe_attr_and_value = match stmt {
@@ -365,6 +385,7 @@ fn collect_self_class_refs_from_init(
             _ => None,
         };
         if let Some((attr_name, value)) = maybe_attr_and_value
+            && attr_name == *target_attr
             && let Some(class_ref) = class_ref_from_constructor_call(
                 value,
                 class_map,
@@ -373,25 +394,28 @@ fn collect_self_class_refs_from_init(
                 module_path,
             )
         {
-            self_attrs.insert(attr_name, class_ref);
+            return Some(class_ref);
         }
     }
 
-    self_attrs
+    None
 }
 
-fn resolve_class_ref_expr(
+fn resolve_class_ref_expr<'a>(
     expr: &Expr,
-    vars: &HashMap<Identifier, VarState>,
+    vars: &'a HashMap<Identifier, VarState>,
     source: &str,
     func_map: &FuncMap,
     imports: &Imports,
     class_map: &ClassMap,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ClassRef> {
+) -> Option<ResolvedClassRef<'a>> {
     match expr {
-        Expr::Name(name) => vars.get(&name.id).and_then(|v| v.class_ref.clone()),
+        Expr::Name(name) => vars
+            .get(&name.id)
+            .and_then(|v| v.class_ref.as_ref())
+            .map(ResolvedClassRef::Borrowed),
         Expr::Attribute(attr) => {
             let base_class_ref = resolve_class_ref_expr(
                 attr.value.as_ref(),
@@ -404,7 +428,7 @@ fn resolve_class_ref_expr(
                 module_path,
             )?;
             with_class_info(
-                &base_class_ref,
+                base_class_ref.as_ref(),
                 source,
                 func_map,
                 imports,
@@ -418,18 +442,21 @@ fn resolve_class_ref_expr(
                  callee_class_map,
                  callee_path,
                  module_cache| {
-                    collect_self_class_refs_from_init(
-                        class_info.init.as_ref(),
+                    find_self_class_ref_in_init(
+                        class_info
+                            .init_name
+                            .as_ref()
+                            .and_then(|name| class_info.methods.get(name)),
+                        &attr.attr,
                         callee_class_map,
                         callee_imports,
                         module_cache.as_deref_mut(),
                         callee_path,
                     )
-                    .get(&attr.attr)
-                    .cloned()
                 },
             )
             .flatten()
+            .map(ResolvedClassRef::Owned)
         }
         _ => None,
     }

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -1,14 +1,24 @@
+//! Module loading and cross-file class resolution.
+//!
+//! This file keeps the parsed metadata needed to:
+//! - resolve imported user-defined modules,
+//! - follow `self.<attr>` references initialized in `__init__`,
+//! - and cache that work across LSP requests.
+
 use crate::VarState;
+use crate::infer::infer_creation_size;
+use crate::infer_expr_shape;
 use crate::normalize_return_annotations;
-use crate::op_groups::{Imports, collect_imports};
+use crate::op_groups::{Imports, TorchOp, collect_imports};
 use rustpython_parser::Parse;
-use rustpython_parser::ast::{Arguments, Expr, Identifier, Stmt, Suite};
+use rustpython_parser::ast::{Arguments, Expr, ExprCall, Identifier, Stmt, Suite};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+/// Lightweight copy of a function definition used during symbolic dispatch.
 #[derive(Clone)]
 pub(crate) struct FunctionInfo {
     pub(crate) args: Box<Arguments>,
@@ -18,30 +28,35 @@ pub(crate) struct FunctionInfo {
 
 pub(crate) type FuncMap = HashMap<Identifier, FunctionInfo>;
 
+/// Reference to a user-defined class, either in the current module or an import.
 #[derive(Debug, Clone)]
 pub(crate) struct ClassRef {
     pub(crate) name: Identifier,
     pub(crate) module: Option<String>,
 }
 
+/// Cached metadata for a class plus lazily discovered `self.<attr>` states.
 #[derive(Clone)]
 pub(crate) struct ClassInfo {
     pub(crate) is_torch_module: bool,
     pub(crate) forward_name: Option<Identifier>,
     pub(crate) methods: HashMap<Identifier, FunctionInfo>,
-    self_attr_refs: RefCell<Option<HashMap<Identifier, ClassRef>>>,
+    self_attr_states: RefCell<Option<HashMap<Identifier, VarState>>>,
 }
 
 pub(crate) type ClassMap = HashMap<Identifier, ClassInfo>;
 
+/// Parsed module data reused by cross-file inference.
 pub(crate) struct CachedModule {
     pub(crate) file_path: PathBuf,
     pub(crate) source: String,
+    pub(crate) body: Suite,
     pub(crate) func_map: FuncMap,
     pub(crate) imports: Imports,
     pub(crate) class_map: ClassMap,
 }
 
+/// Incremental cache for parsed modules, keyed by normalized file path.
 pub struct ModuleCache {
     modules: HashMap<PathBuf, Rc<CachedModule>>,
     resolved_paths: HashMap<(PathBuf, String), Option<PathBuf>>,
@@ -101,8 +116,6 @@ impl ModuleCache {
     }
 
     fn load_module(&mut self, file_path: &Path, source: String) -> Option<Rc<CachedModule>> {
-        let normalized = normalize_return_annotations(&source);
-        let source = normalized.into_owned();
         let module = Suite::parse(&source, &file_path.to_string_lossy()).ok()?;
         let project_root = self.project_root_for(file_path);
         let imports = collect_imports(&module, Some(file_path), project_root.as_deref());
@@ -112,10 +125,61 @@ impl ModuleCache {
         Some(Rc::new(CachedModule {
             file_path: file_path.to_path_buf(),
             source,
+            body: module,
             func_map,
             imports,
             class_map,
         }))
+    }
+
+    fn load_normalized_module(
+        &mut self,
+        file_path: &Path,
+        source: String,
+    ) -> Option<Rc<CachedModule>> {
+        self.load_module(file_path, source)
+    }
+
+    fn normalized_source(source: &str) -> String {
+        normalize_return_annotations(source).into_owned()
+    }
+
+    pub(crate) fn get_file_module(
+        &mut self,
+        file_path: &Path,
+        source: Option<&str>,
+    ) -> Option<Rc<CachedModule>> {
+        let file_path = self.normalize_file_path(file_path);
+        self.remember_path(&file_path);
+
+        if let Some(source) = source {
+            let normalized = Self::normalized_source(source);
+            if !self.dirty_files.contains(&file_path)
+                && let Some(cached) = self.modules.get(&file_path)
+                && cached.source == normalized
+            {
+                return Some(Rc::clone(cached));
+            }
+            let cached = self.load_normalized_module(&file_path, normalized)?;
+            self.modules.insert(file_path.clone(), Rc::clone(&cached));
+            self.dirty_files.remove(&file_path);
+            return Some(cached);
+        }
+
+        if !self.dirty_files.contains(&file_path)
+            && let Some(cached) = self.modules.get(&file_path)
+        {
+            return Some(Rc::clone(cached));
+        }
+        let source = self
+            .source_overrides
+            .get(&file_path)
+            .cloned()
+            .or_else(|| fs::read_to_string(&file_path).ok())?;
+        let cached = self.load_normalized_module(&file_path, Self::normalized_source(&source))?;
+        self.modules.insert(file_path.clone(), Rc::clone(&cached));
+        self.dirty_files.remove(&file_path);
+        Some(cached)
     }
 
     pub(crate) fn get_module(
@@ -135,20 +199,7 @@ impl ModuleCache {
             self.resolved_paths.insert(resolve_key, normalized.clone());
             normalized?
         };
-        if !self.dirty_files.contains(&file_path)
-            && let Some(cached) = self.modules.get(&file_path)
-        {
-            return Some(Rc::clone(cached));
-        }
-        let source = self
-            .source_overrides
-            .get(&file_path)
-            .cloned()
-            .or_else(|| fs::read_to_string(&file_path).ok())?;
-        let cached = self.load_module(&file_path, source)?;
-        self.modules.insert(file_path.clone(), Rc::clone(&cached));
-        self.dirty_files.remove(&file_path);
-        Some(cached)
+        self.get_file_module(&file_path, None)
     }
 }
 
@@ -158,6 +209,7 @@ impl Default for ModuleCache {
     }
 }
 
+/// Returns `1` for instance methods whose first argument is `self`.
 pub(crate) fn method_param_offset(args: &Arguments) -> usize {
     match args.args.first() {
         Some(param) if param.def.arg.as_str() == "self" => 1,
@@ -165,6 +217,7 @@ pub(crate) fn method_param_offset(args: &Arguments) -> usize {
     }
 }
 
+/// Collect all top-level function definitions in a module body.
 pub(crate) fn collect_function_defs(body: &[Stmt], func_map: &mut FuncMap) {
     for stmt in body {
         if let Stmt::FunctionDef(func) = stmt {
@@ -210,6 +263,7 @@ fn is_torch_nn_module_base(expr: &Expr, imports: &Imports) -> bool {
     }
 }
 
+/// Collect class definitions and mark which ones inherit from `torch.nn.Module`.
 pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
     let mut defs = HashMap::new();
     for stmt in body {
@@ -281,7 +335,7 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
                     is_torch_module: is_torch.get(&name).copied().unwrap_or(false),
                     forward_name: info.forward_name,
                     methods: info.methods,
-                    self_attr_refs: RefCell::new(None),
+                    self_attr_states: RefCell::new(None),
                 },
             )
         })
@@ -309,6 +363,7 @@ impl<'a> ResolvedClassRef<'a> {
     }
 }
 
+/// Look up the metadata behind a [`ClassRef`], loading the defining module if needed.
 pub(crate) fn with_class_info<R, F>(
     class_ref: &ClassRef,
     source: &str,
@@ -365,6 +420,7 @@ where
     }
 }
 
+/// Resolve a class annotation such as `UserLinear` or an imported alias.
 pub(crate) fn class_ref_from_annotation(
     ann: &Expr,
     imports: &Imports,
@@ -387,6 +443,7 @@ pub(crate) fn class_ref_from_annotation(
     None
 }
 
+/// Resolve a class-valued expression from either a constructor call or a bound variable.
 pub(crate) fn class_ref_from_expr<'a>(
     expr: &Expr,
     vars: &'a HashMap<Identifier, VarState>,
@@ -428,69 +485,358 @@ fn self_attr_name(expr: &Expr) -> Option<Identifier> {
     (name.id.as_str() == "self").then(|| attr.attr.clone())
 }
 
-fn collect_self_attr_refs_from_init(
-    init: Option<&FunctionInfo>,
+fn self_attr_storage_key(attr: &Identifier) -> Identifier {
+    Identifier::from(format!("self.{}", attr.as_str()))
+}
+
+fn shape_state(shape: crate::Shape) -> VarState {
+    VarState {
+        annotated: None,
+        inferred: Some(shape),
+        class_ref: None,
+    }
+}
+
+fn class_state(class_ref: ClassRef) -> VarState {
+    VarState {
+        annotated: None,
+        inferred: None,
+        class_ref: Some(class_ref),
+    }
+}
+
+fn is_torch_namespace(expr: &Expr, imports: &Imports) -> bool {
+    matches!(expr, Expr::Name(name) if imports.torch_aliases.contains(&name.id))
+}
+
+fn imported_class_ref(
+    module_name: &str,
+    class_name: &Identifier,
+    module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ClassRef> {
+    if module_name == "torch" || module_name.starts_with("torch.") {
+        return None;
+    }
+    let (Some(cache), Some(cur_path)) = (module_cache, module_path) else {
+        return None;
+    };
+    let module = cache.get_module(module_name, cur_path)?;
+    module.class_map.contains_key(class_name).then(|| ClassRef {
+        name: class_name.clone(),
+        module: Some(module_name.to_string()),
+    })
+}
+
+pub(crate) fn is_parameter_constructor(func: &Expr, imports: &Imports) -> bool {
+    match func {
+        Expr::Name(name) => imports
+            .from_imports
+            .get(&name.id)
+            .map(|(module, original)| module == "torch.nn" && original.as_str() == "Parameter")
+            .unwrap_or(false),
+        Expr::Attribute(attr) if attr.attr.as_str() == "Parameter" => match attr.value.as_ref() {
+            Expr::Name(name) => imports
+                .module_aliases
+                .get(&name.id)
+                .map(|module| module == "torch.nn")
+                .unwrap_or(false),
+            Expr::Attribute(nn_attr)
+                if nn_attr.attr.as_str() == "nn"
+                    && is_torch_namespace(nn_attr.value.as_ref(), imports) =>
+            {
+                true
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn torch_call_op(func: &Expr, imports: &Imports) -> TorchOp {
+    match func {
+        Expr::Name(name) => TorchOp::as_call(&name.id, imports),
+        Expr::Attribute(attr) if is_torch_namespace(attr.value.as_ref(), imports) => {
+            TorchOp::from_attr(attr.attr.as_str())
+        }
+        _ => TorchOp::Unknown,
+    }
+}
+
+fn creation_call_shape(
+    call: &ExprCall,
+    vars: &HashMap<Identifier, VarState>,
+    imports: &Imports,
+    source: &str,
+) -> Option<crate::Shape> {
+    let torch_op = torch_call_op(call.func.as_ref(), imports);
+    let TorchOp::Creation { is_size } = torch_op else {
+        return None;
+    };
+    let mut diagnostics = Vec::new();
+    infer_creation_size(call, vars, &mut diagnostics, source, None, None, is_size)
+}
+
+/// Infer the cached state for a value assigned in `__init__`.
+///
+/// Only class constructors, `torch.nn.Parameter(...)`, and tensor creation calls are tracked.
+fn infer_tracked_state_from_expr(
+    expr: &Expr,
+    vars: &HashMap<Identifier, VarState>,
+    self_attrs: &HashMap<Identifier, VarState>,
     class_map: &ClassMap,
     imports: &Imports,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> HashMap<Identifier, ClassRef> {
-    let Some(init) = init else {
-        return HashMap::new();
-    };
-    let mut refs = HashMap::new();
+    source: &str,
+) -> Option<VarState> {
+    if let Some(class_ref) = class_ref_from_constructor_call(
+        expr,
+        class_map,
+        imports,
+        module_cache.as_deref_mut(),
+        module_path,
+    ) {
+        return Some(class_state(class_ref));
+    }
 
-    for stmt in &init.body {
-        let maybe_attr_and_value = match stmt {
-            Stmt::Assign(assign) if assign.targets.len() == 1 => self_attr_name(&assign.targets[0])
-                .map(|attr_name| (attr_name, assign.value.as_ref())),
-            Stmt::AnnAssign(assign) => assign.value.as_deref().and_then(|value| {
-                self_attr_name(&assign.target).map(|attr_name| (attr_name, value))
-            }),
-            _ => None,
-        };
-        if let Some((attr_name, value)) = maybe_attr_and_value {
-            if let Some(class_ref) = class_ref_from_constructor_call(
-                value,
+    if let Expr::Name(name) = expr {
+        return vars.get(&name.id).cloned();
+    }
+
+    if let Some(attr_name) = self_attr_name(expr) {
+        return vars
+            .get(&self_attr_storage_key(&attr_name))
+            .cloned()
+            .or_else(|| self_attrs.get(&attr_name).cloned());
+    }
+
+    if let Expr::Call(call) = expr {
+        if is_parameter_constructor(call.func.as_ref(), imports) {
+            let first_arg = call.args.first()?;
+            return infer_tracked_state_from_expr(
+                first_arg,
+                vars,
+                self_attrs,
                 class_map,
                 imports,
                 module_cache.as_deref_mut(),
                 module_path,
-            ) {
-                refs.insert(attr_name, class_ref);
-            } else {
-                refs.remove(&attr_name);
-            }
+                source,
+            )
+            .and_then(|state| state.annotated.or(state.inferred).map(shape_state));
+        }
+
+        if let Some(shape) = creation_call_shape(call, vars, imports, source) {
+            return Some(shape_state(shape));
         }
     }
 
-    refs
+    let mut diagnostics = Vec::new();
+    let mut hover_entries = Vec::new();
+    let mut call_stack = Vec::new();
+    infer_expr_shape(
+        expr,
+        vars,
+        &FuncMap::new(),
+        imports,
+        class_map,
+        &mut call_stack,
+        &mut diagnostics,
+        &mut hover_entries,
+        false,
+        source,
+        module_cache,
+        module_path,
+    )
+    .map(shape_state)
 }
 
-fn get_or_collect_self_attr_ref(
-    class_info: &ClassInfo,
-    target_attr: &Identifier,
+fn update_tracked_binding(
+    target: &Expr,
+    value: &Expr,
+    vars: &mut HashMap<Identifier, VarState>,
+    self_attrs: &mut HashMap<Identifier, VarState>,
     class_map: &ClassMap,
     imports: &Imports,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ClassRef> {
-    if class_info.self_attr_refs.borrow().is_none() {
-        let refs = collect_self_attr_refs_from_init(
+    source: &str,
+) {
+    let state = infer_tracked_state_from_expr(
+        value,
+        vars,
+        self_attrs,
+        class_map,
+        imports,
+        module_cache.as_deref_mut(),
+        module_path,
+        source,
+    );
+    if let Some(attr_name) = self_attr_name(target) {
+        if let Some(state) = state {
+            vars.insert(self_attr_storage_key(&attr_name), state.clone());
+            self_attrs.insert(attr_name, state);
+        } else {
+            vars.remove(&self_attr_storage_key(&attr_name));
+            self_attrs.remove(&attr_name);
+        }
+    } else if let Expr::Name(name) = target {
+        if let Some(state) = state {
+            vars.insert(name.id.clone(), state);
+        } else {
+            vars.remove(&name.id);
+        }
+    }
+}
+
+/// Scan `__init__` once and cache every tracked `self.<attr>` assignment.
+fn collect_self_attr_states_from_init(
+    init: Option<&FunctionInfo>,
+    source: &str,
+    class_map: &ClassMap,
+    imports: &Imports,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> HashMap<Identifier, VarState> {
+    let Some(init) = init else {
+        return HashMap::new();
+    };
+    let mut vars = HashMap::from([(Identifier::from("self"), VarState::default())]);
+    let mut states = HashMap::new();
+
+    for stmt in &init.body {
+        match stmt {
+            Stmt::Assign(assign) if assign.targets.len() == 1 => update_tracked_binding(
+                &assign.targets[0],
+                &assign.value,
+                &mut vars,
+                &mut states,
+                class_map,
+                imports,
+                module_cache.as_deref_mut(),
+                module_path,
+                source,
+            ),
+            Stmt::AnnAssign(assign) if assign.value.is_some() => update_tracked_binding(
+                assign.target.as_ref(),
+                assign.value.as_deref().unwrap(),
+                &mut vars,
+                &mut states,
+                class_map,
+                imports,
+                module_cache.as_deref_mut(),
+                module_path,
+                source,
+            ),
+            _ => {}
+        }
+    }
+
+    states
+}
+
+fn get_or_collect_self_attr_state(
+    class_info: &ClassInfo,
+    target_attr: &Identifier,
+    source: &str,
+    class_map: &ClassMap,
+    imports: &Imports,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<VarState> {
+    if class_info.self_attr_states.borrow().is_none() {
+        let states = collect_self_attr_states_from_init(
             class_info.methods.get(&Identifier::from("__init__")),
+            source,
             class_map,
             imports,
             module_cache.as_deref_mut(),
             module_path,
         );
-        *class_info.self_attr_refs.borrow_mut() = Some(refs);
+        *class_info.self_attr_states.borrow_mut() = Some(states);
     }
     class_info
-        .self_attr_refs
+        .self_attr_states
         .borrow()
         .as_ref()
-        .and_then(|refs| refs.get(target_attr))
+        .and_then(|states| states.get(target_attr))
         .cloned()
+}
+
+fn resolve_cached_self_attr_state(
+    base_class_ref: &ClassRef,
+    target_attr: &Identifier,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    module_cache: &mut Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<VarState> {
+    with_class_info(
+        base_class_ref,
+        source,
+        func_map,
+        imports,
+        class_map,
+        module_cache,
+        module_path,
+        |class_info,
+         callee_source,
+         _callee_func_map,
+         callee_imports,
+         callee_class_map,
+         callee_path,
+         module_cache| {
+            get_or_collect_self_attr_state(
+                class_info,
+                target_attr,
+                callee_source,
+                callee_class_map,
+                callee_imports,
+                module_cache.as_deref_mut(),
+                callee_path,
+            )
+        },
+    )
+    .flatten()
+}
+
+/// Resolve an attribute access such as `self.weight` to the cached state from `__init__`.
+pub(crate) fn attr_state_from_expr(
+    expr: &Expr,
+    vars: &HashMap<Identifier, VarState>,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<VarState> {
+    let Expr::Attribute(attr) = expr else {
+        return None;
+    };
+    let base_class_ref = resolve_class_ref_expr(
+        attr.value.as_ref(),
+        vars,
+        source,
+        func_map,
+        imports,
+        class_map,
+        module_cache.as_deref_mut(),
+        module_path,
+    )?;
+    resolve_cached_self_attr_state(
+        base_class_ref.as_ref(),
+        &attr.attr,
+        source,
+        func_map,
+        imports,
+        class_map,
+        &mut module_cache,
+        module_path,
+    )
 }
 
 fn resolve_class_ref_expr<'a>(
@@ -519,38 +865,24 @@ fn resolve_class_ref_expr<'a>(
                 module_cache.as_deref_mut(),
                 module_path,
             )?;
-            with_class_info(
+            resolve_cached_self_attr_state(
                 base_class_ref.as_ref(),
+                &attr.attr,
                 source,
                 func_map,
                 imports,
                 class_map,
                 &mut module_cache,
                 module_path,
-                |class_info,
-                 _callee_source,
-                 _callee_func_map,
-                 callee_imports,
-                 callee_class_map,
-                 callee_path,
-                 module_cache| {
-                    get_or_collect_self_attr_ref(
-                        class_info,
-                        &attr.attr,
-                        callee_class_map,
-                        callee_imports,
-                        module_cache.as_deref_mut(),
-                        callee_path,
-                    )
-                },
             )
-            .flatten()
+            .and_then(|state| state.class_ref)
             .map(ResolvedClassRef::Owned)
         }
         _ => None,
     }
 }
 
+/// Resolve constructor calls to user-defined classes, including imported classes.
 fn class_ref_from_constructor_call(
     call_expr: &Expr,
     class_map: &ClassMap,
@@ -570,31 +902,23 @@ fn class_ref_from_constructor_call(
                 });
             }
             if let Some((module_name, original)) = imports.from_imports.get(&name.id)
-                && module_name != "torch"
-                && !module_name.starts_with("torch.")
-                && let (Some(cache), Some(cur_path)) = (module_cache.as_deref_mut(), module_path)
-                && let Some(module) = cache.get_module(module_name, cur_path)
-                && module.class_map.contains_key(original)
+                && let Some(class_ref) = imported_class_ref(
+                    module_name,
+                    original,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                )
             {
-                return Some(ClassRef {
-                    name: original.clone(),
-                    module: Some(module_name.to_string()),
-                });
+                return Some(class_ref);
             }
         }
         Expr::Attribute(attr) => {
             if let Expr::Name(module_ident) = attr.value.as_ref()
                 && let Some(module_name) = imports.module_aliases.get(&module_ident.id)
-                && module_name != "torch"
-                && !module_name.starts_with("torch.")
-                && let (Some(cache), Some(cur_path)) = (module_cache, module_path)
-                && let Some(module) = cache.get_module(module_name, cur_path)
-                && module.class_map.contains_key(&attr.attr)
+                && let Some(class_ref) =
+                    imported_class_ref(module_name, &attr.attr, module_cache, module_path)
             {
-                return Some(ClassRef {
-                    name: attr.attr.clone(),
-                    module: Some(module_name.to_string()),
-                });
+                return Some(class_ref);
             }
         }
         _ => {}
@@ -672,6 +996,7 @@ fn find_module_path_recursively(root: &Path, relative: &Path) -> Option<PathBuf>
     None
 }
 
+/// Resolve an import like `a.b.c` to the python file that defines it.
 fn resolve_module_path(
     module: &str,
     current_file: &Path,

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -659,7 +659,7 @@ fn update_tracked_binding(
     self_attrs: &mut HashMap<Identifier, VarState>,
     class_map: &ClassMap,
     imports: &Imports,
-    mut module_cache: Option<&mut ModuleCache>,
+    module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
     source: &str,
 ) {
@@ -669,7 +669,7 @@ fn update_tracked_binding(
         self_attrs,
         class_map,
         imports,
-        module_cache.as_deref_mut(),
+        module_cache,
         module_path,
         source,
     );
@@ -742,7 +742,7 @@ fn get_or_collect_self_attr_state(
     source: &str,
     class_map: &ClassMap,
     imports: &Imports,
-    mut module_cache: Option<&mut ModuleCache>,
+    module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<VarState> {
     if class_info.self_attr_states.borrow().is_none() {
@@ -751,7 +751,7 @@ fn get_or_collect_self_attr_state(
             source,
             class_map,
             imports,
-            module_cache.as_deref_mut(),
+            module_cache,
             module_path,
         );
         *class_info.self_attr_states.borrow_mut() = Some(states);

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -3,7 +3,8 @@ use crate::normalize_return_annotations;
 use crate::op_groups::{Imports, collect_imports};
 use rustpython_parser::Parse;
 use rustpython_parser::ast::{Arguments, Expr, Identifier, Stmt, Suite};
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -26,37 +27,95 @@ pub(crate) struct ClassRef {
 #[derive(Clone)]
 pub(crate) struct ClassInfo {
     pub(crate) is_torch_module: bool,
-    pub(crate) init_name: Option<Identifier>,
     pub(crate) forward_name: Option<Identifier>,
     pub(crate) methods: HashMap<Identifier, FunctionInfo>,
+    self_attr_refs: RefCell<Option<HashMap<Identifier, ClassRef>>>,
 }
 
 pub(crate) type ClassMap = HashMap<Identifier, ClassInfo>;
 
 pub(crate) struct CachedModule {
-    pub(crate) path: PathBuf,
+    pub(crate) file_path: PathBuf,
     pub(crate) source: String,
     pub(crate) func_map: FuncMap,
     pub(crate) imports: Imports,
     pub(crate) class_map: ClassMap,
 }
 
-pub(crate) struct ModuleCache {
-    modules: HashMap<String, Rc<CachedModule>>,
-    project_root: Option<PathBuf>,
+pub struct ModuleCache {
+    modules: HashMap<PathBuf, Rc<CachedModule>>,
+    resolved_paths: HashMap<(PathBuf, String), Option<PathBuf>>,
+    dirty_files: HashSet<PathBuf>,
+    source_overrides: HashMap<PathBuf, String>,
+    project_roots: HashSet<PathBuf>,
+    cwd: PathBuf,
 }
 
 impl ModuleCache {
-    pub(crate) fn new(current_file: &Path) -> Self {
-        let project_root = find_project_root(current_file);
+    pub fn new() -> Self {
         Self {
             modules: HashMap::new(),
-            project_root,
+            resolved_paths: HashMap::new(),
+            dirty_files: HashSet::new(),
+            source_overrides: HashMap::new(),
+            project_roots: HashSet::new(),
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
         }
     }
 
-    pub(crate) fn project_root(&self) -> Option<&Path> {
-        self.project_root.as_deref()
+    pub fn update_file_source(&mut self, file_path: &Path, source: String) {
+        self.remember_path(file_path);
+        let file_path = self.normalize_file_path(file_path);
+        self.source_overrides.insert(file_path.clone(), source);
+        self.dirty_files.insert(file_path);
+    }
+
+    pub fn mark_file_changed(&mut self, file_path: &Path) {
+        self.remember_path(file_path);
+        self.dirty_files.insert(self.normalize_file_path(file_path));
+    }
+
+    pub(crate) fn project_root_for(&mut self, current_file: &Path) -> Option<PathBuf> {
+        let current_file = self.normalize_file_path(current_file);
+        if let Some(root) = self
+            .project_roots
+            .iter()
+            .filter(|root| current_file.starts_with(root))
+            .max_by_key(|root| root.components().count())
+        {
+            return Some(root.clone());
+        }
+        let root = find_project_root(&current_file).map(|root| self.normalize_file_path(&root));
+        if let Some(root) = &root {
+            self.project_roots.insert(root.clone());
+        }
+        root
+    }
+
+    fn remember_path(&mut self, path: &Path) {
+        let _ = self.project_root_for(path);
+    }
+
+    fn normalize_file_path(&self, path: &Path) -> PathBuf {
+        normalize_file_path(path, &self.cwd)
+    }
+
+    fn load_module(&mut self, file_path: &Path, source: String) -> Option<Rc<CachedModule>> {
+        let normalized = normalize_return_annotations(&source);
+        let source = normalized.into_owned();
+        let module = Suite::parse(&source, &file_path.to_string_lossy()).ok()?;
+        let project_root = self.project_root_for(file_path);
+        let imports = collect_imports(&module, Some(file_path), project_root.as_deref());
+        let mut func_map = FuncMap::new();
+        collect_function_defs(&module, &mut func_map);
+        let class_map = collect_class_defs(&module, &imports);
+        Some(Rc::new(CachedModule {
+            file_path: file_path.to_path_buf(),
+            source,
+            func_map,
+            imports,
+            class_map,
+        }))
     }
 
     pub(crate) fn get_module(
@@ -64,28 +123,38 @@ impl ModuleCache {
         module_name: &str,
         current_file: &Path,
     ) -> Option<Rc<CachedModule>> {
-        if let Some(cached) = self.modules.get(module_name) {
+        let current_file = self.normalize_file_path(current_file);
+        self.remember_path(&current_file);
+        let resolve_key = (current_file.clone(), module_name.to_string());
+        let file_path = if let Some(cached_path) = self.resolved_paths.get(&resolve_key) {
+            cached_path.clone()?
+        } else {
+            let project_root = self.project_root_for(&current_file);
+            let path = resolve_module_path(module_name, &current_file, project_root.as_deref());
+            let normalized = path.as_ref().map(|path| self.normalize_file_path(path));
+            self.resolved_paths.insert(resolve_key, normalized.clone());
+            normalized?
+        };
+        if !self.dirty_files.contains(&file_path)
+            && let Some(cached) = self.modules.get(&file_path)
+        {
             return Some(Rc::clone(cached));
         }
-        let path = resolve_module_path(module_name, current_file, self.project_root.as_deref())?;
-        let source = fs::read_to_string(&path).ok()?;
-        let normalized = normalize_return_annotations(&source);
-        let source = normalized.into_owned();
-        let module = Suite::parse(&source, module_name).ok()?;
-        let imports = collect_imports(&module, Some(&path), self.project_root());
-        let mut func_map = FuncMap::new();
-        collect_function_defs(&module, &mut func_map);
-        let class_map = collect_class_defs(&module, &imports);
-        let cached = Rc::new(CachedModule {
-            path,
-            source,
-            func_map,
-            imports,
-            class_map,
-        });
-        self.modules
-            .insert(module_name.to_string(), Rc::clone(&cached));
+        let source = self
+            .source_overrides
+            .get(&file_path)
+            .cloned()
+            .or_else(|| fs::read_to_string(&file_path).ok())?;
+        let cached = self.load_module(&file_path, source)?;
+        self.modules.insert(file_path.clone(), Rc::clone(&cached));
+        self.dirty_files.remove(&file_path);
         Some(cached)
+    }
+}
+
+impl Default for ModuleCache {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -112,7 +181,6 @@ pub(crate) fn collect_function_defs(body: &[Stmt], func_map: &mut FuncMap) {
 }
 
 struct ClassDefInfo {
-    init_name: Option<Identifier>,
     forward_name: Option<Identifier>,
     methods: HashMap<Identifier, FunctionInfo>,
     base_names: Vec<Identifier>,
@@ -147,7 +215,6 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
     for stmt in body {
         if let Stmt::ClassDef(class_def) = stmt {
             let mut methods = HashMap::new();
-            let mut init_name = None;
             let mut forward_name = None;
             for stmt in &class_def.body {
                 if let Stmt::FunctionDef(func) = stmt {
@@ -156,9 +223,6 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
                         body: func.body.clone(),
                         returns: func.returns.clone(),
                     };
-                    if func.name.as_str() == "__init__" {
-                        init_name = Some(func.name.clone());
-                    }
                     if func.name.as_str() == "forward" {
                         forward_name = Some(func.name.clone());
                     }
@@ -180,7 +244,6 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
             defs.insert(
                 class_def.name.clone(),
                 ClassDefInfo {
-                    init_name,
                     forward_name,
                     methods,
                     base_names,
@@ -216,9 +279,9 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
                 name.clone(),
                 ClassInfo {
                     is_torch_module: is_torch.get(&name).copied().unwrap_or(false),
-                    init_name: info.init_name,
                     forward_name: info.forward_name,
                     methods: info.methods,
+                    self_attr_refs: RefCell::new(None),
                 },
             )
         })
@@ -283,7 +346,7 @@ where
                 &module.func_map,
                 &module.imports,
                 &module.class_map,
-                Some(module.path.as_path()),
+                Some(module.file_path.as_path()),
                 module_cache,
             ))
         }
@@ -365,15 +428,17 @@ fn self_attr_name(expr: &Expr) -> Option<Identifier> {
     (name.id.as_str() == "self").then(|| attr.attr.clone())
 }
 
-fn find_self_class_ref_in_init(
+fn collect_self_attr_refs_from_init(
     init: Option<&FunctionInfo>,
-    target_attr: &Identifier,
     class_map: &ClassMap,
     imports: &Imports,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ClassRef> {
-    let init = init?;
+) -> HashMap<Identifier, ClassRef> {
+    let Some(init) = init else {
+        return HashMap::new();
+    };
+    let mut refs = HashMap::new();
 
     for stmt in &init.body {
         let maybe_attr_and_value = match stmt {
@@ -384,21 +449,48 @@ fn find_self_class_ref_in_init(
             }),
             _ => None,
         };
-        if let Some((attr_name, value)) = maybe_attr_and_value
-            && attr_name == *target_attr
-            && let Some(class_ref) = class_ref_from_constructor_call(
+        if let Some((attr_name, value)) = maybe_attr_and_value {
+            if let Some(class_ref) = class_ref_from_constructor_call(
                 value,
                 class_map,
                 imports,
                 module_cache.as_deref_mut(),
                 module_path,
-            )
-        {
-            return Some(class_ref);
+            ) {
+                refs.insert(attr_name, class_ref);
+            } else {
+                refs.remove(&attr_name);
+            }
         }
     }
 
-    None
+    refs
+}
+
+fn get_or_collect_self_attr_ref(
+    class_info: &ClassInfo,
+    target_attr: &Identifier,
+    class_map: &ClassMap,
+    imports: &Imports,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ClassRef> {
+    if class_info.self_attr_refs.borrow().is_none() {
+        let refs = collect_self_attr_refs_from_init(
+            class_info.methods.get(&Identifier::from("__init__")),
+            class_map,
+            imports,
+            module_cache.as_deref_mut(),
+            module_path,
+        );
+        *class_info.self_attr_refs.borrow_mut() = Some(refs);
+    }
+    class_info
+        .self_attr_refs
+        .borrow()
+        .as_ref()
+        .and_then(|refs| refs.get(target_attr))
+        .cloned()
 }
 
 fn resolve_class_ref_expr<'a>(
@@ -442,11 +534,8 @@ fn resolve_class_ref_expr<'a>(
                  callee_class_map,
                  callee_path,
                  module_cache| {
-                    find_self_class_ref_in_init(
-                        class_info
-                            .init_name
-                            .as_ref()
-                            .and_then(|name| class_info.methods.get(name)),
+                    get_or_collect_self_attr_ref(
+                        class_info,
                         &attr.attr,
                         callee_class_map,
                         callee_imports,
@@ -530,6 +619,27 @@ fn find_project_root(start: &Path) -> Option<PathBuf> {
         dir = current.parent();
     }
     None
+}
+
+fn normalize_file_path(path: &Path, cwd: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
 }
 
 fn should_skip_module_search_dir(path: &Path) -> bool {

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -1,0 +1,638 @@
+use crate::VarState;
+use crate::normalize_return_annotations;
+use crate::op_groups::{Imports, collect_imports};
+use rustpython_parser::Parse;
+use rustpython_parser::ast::{Arguments, Expr, Identifier, Stmt, Suite};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub(crate) struct FunctionInfo {
+    pub(crate) args: Box<Arguments>,
+    pub(crate) body: Vec<Stmt>,
+    pub(crate) returns: Option<Box<Expr>>,
+}
+
+pub(crate) type FuncMap = HashMap<Identifier, FunctionInfo>;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClassRef {
+    pub(crate) name: Identifier,
+    pub(crate) module: Option<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ClassInfo {
+    pub(crate) is_torch_module: bool,
+    pub(crate) init: Option<FunctionInfo>,
+    pub(crate) forward: Option<FunctionInfo>,
+    pub(crate) methods: HashMap<Identifier, FunctionInfo>,
+}
+
+pub(crate) type ClassMap = HashMap<Identifier, ClassInfo>;
+
+#[derive(Clone)]
+pub(crate) struct CachedModule {
+    pub(crate) path: PathBuf,
+    pub(crate) source: String,
+    pub(crate) func_map: FuncMap,
+    pub(crate) imports: Imports,
+    pub(crate) class_map: ClassMap,
+}
+
+pub(crate) struct ModuleCache {
+    modules: HashMap<String, CachedModule>,
+    project_root: Option<PathBuf>,
+}
+
+impl ModuleCache {
+    pub(crate) fn new(current_file: &Path) -> Self {
+        let project_root = find_project_root(current_file);
+        Self {
+            modules: HashMap::new(),
+            project_root,
+        }
+    }
+
+    pub(crate) fn project_root(&self) -> Option<&Path> {
+        self.project_root.as_deref()
+    }
+
+    pub(crate) fn get_module(
+        &mut self,
+        module_name: &str,
+        current_file: &Path,
+    ) -> Option<CachedModule> {
+        if let Some(cached) = self.modules.get(module_name) {
+            return Some(cached.clone());
+        }
+        let path = resolve_module_path(module_name, current_file, self.project_root.as_deref())?;
+        let source = fs::read_to_string(&path).ok()?;
+        let normalized = normalize_return_annotations(&source);
+        let source = normalized.into_owned();
+        let module = Suite::parse(&source, module_name).ok()?;
+        let imports = collect_imports(&module, Some(&path), self.project_root());
+        let mut func_map = FuncMap::new();
+        collect_function_defs(&module, &mut func_map);
+        let class_map = collect_class_defs(&module, &imports);
+        let cached = CachedModule {
+            path,
+            source,
+            func_map,
+            imports,
+            class_map,
+        };
+        self.modules.insert(module_name.to_string(), cached.clone());
+        Some(cached)
+    }
+}
+
+pub(crate) fn method_param_offset(args: &Arguments) -> usize {
+    match args.args.first() {
+        Some(param) if param.def.arg.as_str() == "self" => 1,
+        _ => 0,
+    }
+}
+
+pub(crate) fn collect_function_defs(body: &[Stmt], func_map: &mut FuncMap) {
+    for stmt in body {
+        if let Stmt::FunctionDef(func) = stmt {
+            func_map.insert(
+                func.name.clone(),
+                FunctionInfo {
+                    args: func.args.clone(),
+                    body: func.body.clone(),
+                    returns: func.returns.clone(),
+                },
+            );
+        }
+    }
+}
+
+struct ClassDefInfo {
+    init: Option<FunctionInfo>,
+    forward: Option<FunctionInfo>,
+    methods: HashMap<Identifier, FunctionInfo>,
+    base_names: Vec<Identifier>,
+    direct_torch: bool,
+}
+
+fn is_torch_nn_module_base(expr: &Expr, imports: &Imports) -> bool {
+    let Expr::Attribute(attr) = expr else {
+        return false;
+    };
+    if attr.attr.as_str() != "Module" {
+        return false;
+    }
+    match attr.value.as_ref() {
+        Expr::Attribute(nn_attr) if nn_attr.attr.as_str() == "nn" => {
+            if let Expr::Name(torch_name) = nn_attr.value.as_ref() {
+                return imports.torch_aliases.contains(&torch_name.id);
+            }
+            false
+        }
+        Expr::Name(nn_name) => imports
+            .module_aliases
+            .get(&nn_name.id)
+            .map(|module| module == "torch.nn")
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
+    let mut defs = HashMap::new();
+    for stmt in body {
+        if let Stmt::ClassDef(class_def) = stmt {
+            let mut methods = HashMap::new();
+            let mut init = None;
+            let mut forward = None;
+            for stmt in &class_def.body {
+                if let Stmt::FunctionDef(func) = stmt {
+                    let info = FunctionInfo {
+                        args: func.args.clone(),
+                        body: func.body.clone(),
+                        returns: func.returns.clone(),
+                    };
+                    if func.name.as_str() == "__init__" {
+                        init = Some(info.clone());
+                    }
+                    if func.name.as_str() == "forward" {
+                        forward = Some(info.clone());
+                    }
+                    methods.insert(func.name.clone(), info);
+                }
+            }
+            let base_names = class_def
+                .bases
+                .iter()
+                .filter_map(|base| match base {
+                    Expr::Name(name) => Some(name.id.clone()),
+                    _ => None,
+                })
+                .collect();
+            let direct_torch = class_def
+                .bases
+                .iter()
+                .any(|base| is_torch_nn_module_base(base, imports));
+            defs.insert(
+                class_def.name.clone(),
+                ClassDefInfo {
+                    init,
+                    forward,
+                    methods,
+                    base_names,
+                    direct_torch,
+                },
+            );
+        }
+    }
+
+    let mut is_torch: HashMap<Identifier, bool> = defs
+        .iter()
+        .map(|(name, info)| (name.clone(), info.direct_torch))
+        .collect();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (name, info) in &defs {
+            if !is_torch.get(name).copied().unwrap_or(false)
+                && info
+                    .base_names
+                    .iter()
+                    .any(|base| is_torch.get(base).copied().unwrap_or(false))
+            {
+                is_torch.insert(name.clone(), true);
+                changed = true;
+            }
+        }
+    }
+
+    defs.into_iter()
+        .map(|(name, info)| {
+            (
+                name.clone(),
+                ClassInfo {
+                    is_torch_module: is_torch.get(&name).copied().unwrap_or(false),
+                    init: info.init,
+                    forward: info.forward,
+                    methods: info.methods,
+                },
+            )
+        })
+        .collect()
+}
+
+pub(crate) fn with_class_info<R, F>(
+    class_ref: &ClassRef,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    module_cache: &mut Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+    f: F,
+) -> Option<R>
+where
+    F: FnOnce(
+        &ClassInfo,
+        &str,
+        &FuncMap,
+        &Imports,
+        &ClassMap,
+        Option<&Path>,
+        &mut Option<&mut ModuleCache>,
+    ) -> R,
+{
+    match &class_ref.module {
+        Some(module_name) => {
+            let module = {
+                let (Some(cache), Some(cur_path)) = (module_cache.as_deref_mut(), module_path)
+                else {
+                    return None;
+                };
+                cache.get_module(module_name, cur_path)?
+            };
+            let class_info = module.class_map.get(&class_ref.name)?;
+            Some(f(
+                class_info,
+                &module.source,
+                &module.func_map,
+                &module.imports,
+                &module.class_map,
+                Some(module.path.as_path()),
+                module_cache,
+            ))
+        }
+        None => {
+            let class_info = class_map.get(&class_ref.name)?;
+            Some(f(
+                class_info,
+                source,
+                func_map,
+                imports,
+                class_map,
+                module_path,
+                module_cache,
+            ))
+        }
+    }
+}
+
+pub(crate) fn class_ref_from_annotation(
+    ann: &Expr,
+    imports: &Imports,
+    class_map: &ClassMap,
+) -> Option<ClassRef> {
+    if let Expr::Name(name) = ann {
+        if class_map.contains_key(&name.id) {
+            return Some(ClassRef {
+                name: name.id.clone(),
+                module: None,
+            });
+        }
+        if let Some((module_name, original)) = imports.from_imports.get(&name.id) {
+            return Some(ClassRef {
+                name: original.clone(),
+                module: Some(module_name.clone()),
+            });
+        }
+    }
+    None
+}
+
+pub(crate) fn class_ref_from_expr(
+    expr: &Expr,
+    vars: &HashMap<Identifier, VarState>,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ClassRef> {
+    if let Some(class_ref) = class_ref_from_constructor_call(
+        expr,
+        class_map,
+        imports,
+        module_cache.as_deref_mut(),
+        module_path,
+    ) {
+        return Some(class_ref);
+    }
+    resolve_class_ref_expr(
+        expr,
+        vars,
+        source,
+        func_map,
+        imports,
+        class_map,
+        module_cache,
+        module_path,
+    )
+}
+
+fn self_attr_name(expr: &Expr) -> Option<Identifier> {
+    let Expr::Attribute(attr) = expr else {
+        return None;
+    };
+    let Expr::Name(name) = attr.value.as_ref() else {
+        return None;
+    };
+    (name.id.as_str() == "self").then(|| attr.attr.clone())
+}
+
+fn collect_self_class_refs_from_init(
+    init: Option<&FunctionInfo>,
+    class_map: &ClassMap,
+    imports: &Imports,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> HashMap<Identifier, ClassRef> {
+    let mut self_attrs = HashMap::new();
+    let Some(init) = init else {
+        return self_attrs;
+    };
+
+    for stmt in &init.body {
+        let maybe_attr_and_value = match stmt {
+            Stmt::Assign(assign) if assign.targets.len() == 1 => self_attr_name(&assign.targets[0])
+                .map(|attr_name| (attr_name, assign.value.as_ref())),
+            Stmt::AnnAssign(assign) => assign.value.as_deref().and_then(|value| {
+                self_attr_name(&assign.target).map(|attr_name| (attr_name, value))
+            }),
+            _ => None,
+        };
+        if let Some((attr_name, value)) = maybe_attr_and_value
+            && let Some(class_ref) = class_ref_from_constructor_call(
+                value,
+                class_map,
+                imports,
+                module_cache.as_deref_mut(),
+                module_path,
+            )
+        {
+            self_attrs.insert(attr_name, class_ref);
+        }
+    }
+
+    self_attrs
+}
+
+fn resolve_class_ref_expr(
+    expr: &Expr,
+    vars: &HashMap<Identifier, VarState>,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ClassRef> {
+    match expr {
+        Expr::Name(name) => vars.get(&name.id).and_then(|v| v.class_ref.clone()),
+        Expr::Attribute(attr) => {
+            let base_class_ref = resolve_class_ref_expr(
+                attr.value.as_ref(),
+                vars,
+                source,
+                func_map,
+                imports,
+                class_map,
+                module_cache.as_deref_mut(),
+                module_path,
+            )?;
+            with_class_info(
+                &base_class_ref,
+                source,
+                func_map,
+                imports,
+                class_map,
+                &mut module_cache,
+                module_path,
+                |class_info,
+                 _callee_source,
+                 _callee_func_map,
+                 callee_imports,
+                 callee_class_map,
+                 callee_path,
+                 module_cache| {
+                    collect_self_class_refs_from_init(
+                        class_info.init.as_ref(),
+                        callee_class_map,
+                        callee_imports,
+                        module_cache.as_deref_mut(),
+                        callee_path,
+                    )
+                    .get(&attr.attr)
+                    .cloned()
+                },
+            )
+            .flatten()
+        }
+        _ => None,
+    }
+}
+
+fn class_ref_from_constructor_call(
+    call_expr: &Expr,
+    class_map: &ClassMap,
+    imports: &Imports,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ClassRef> {
+    let Expr::Call(call) = call_expr else {
+        return None;
+    };
+    match call.func.as_ref() {
+        Expr::Name(name) => {
+            if class_map.contains_key(&name.id) {
+                return Some(ClassRef {
+                    name: name.id.clone(),
+                    module: None,
+                });
+            }
+            if let Some((module_name, original)) = imports.from_imports.get(&name.id)
+                && module_name != "torch"
+                && !module_name.starts_with("torch.")
+                && let (Some(cache), Some(cur_path)) = (module_cache.as_deref_mut(), module_path)
+                && let Some(module) = cache.get_module(module_name, cur_path)
+                && module.class_map.contains_key(original)
+            {
+                return Some(ClassRef {
+                    name: original.clone(),
+                    module: Some(module_name.to_string()),
+                });
+            }
+        }
+        Expr::Attribute(attr) => {
+            if let Expr::Name(module_ident) = attr.value.as_ref()
+                && let Some(module_name) = imports.module_aliases.get(&module_ident.id)
+                && module_name != "torch"
+                && !module_name.starts_with("torch.")
+                && let (Some(cache), Some(cur_path)) = (module_cache, module_path)
+                && let Some(module) = cache.get_module(module_name, cur_path)
+                && module.class_map.contains_key(&attr.attr)
+            {
+                return Some(ClassRef {
+                    name: attr.attr.clone(),
+                    module: Some(module_name.to_string()),
+                });
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+fn find_project_root(start: &Path) -> Option<PathBuf> {
+    let mut dir = start.parent();
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    while let Some(current) = dir {
+        if current.join(".git").exists()
+            || current.join("pyproject.toml").exists()
+            || current.join("setup.py").exists()
+            || current.join("setup.cfg").exists()
+        {
+            return Some(current.to_path_buf());
+        }
+        if Some(current.to_path_buf()) == home {
+            break;
+        }
+        dir = current.parent();
+    }
+    None
+}
+
+fn should_skip_module_search_dir(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | "target" | "__pycache__" | "node_modules")
+    )
+}
+
+fn find_module_path_recursively(root: &Path, relative: &Path) -> Option<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if should_skip_module_search_dir(&dir) {
+            continue;
+        }
+        let candidate = dir.join(relative);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            }
+        }
+    }
+    None
+}
+
+fn resolve_module_path(
+    module: &str,
+    current_file: &Path,
+    project_root: Option<&Path>,
+) -> Option<PathBuf> {
+    let mut search_roots = Vec::new();
+
+    if let Some(parent) = current_file.parent() {
+        search_roots.push(parent.to_path_buf());
+    }
+    if let Some(prj) = project_root {
+        search_roots.push(prj.to_path_buf());
+        let src_dir = prj.join("src");
+        if src_dir.exists() {
+            search_roots.push(src_dir);
+        }
+    }
+
+    if let Ok(path_var) = std::env::var("PATH") {
+        for entry in path_var.split(':') {
+            if !entry.contains(".venv") {
+                continue;
+            }
+            let mut path = PathBuf::from(entry);
+            while let Some(parent) = path.parent() {
+                if let Some(name) = parent.file_name()
+                    && name.to_string_lossy().contains(".venv")
+                {
+                    let venv_dir = parent.to_path_buf();
+                    if let Some(project_root) = venv_dir.parent() {
+                        search_roots.push(project_root.to_path_buf());
+                    }
+                    let lib_dir = venv_dir.join("lib");
+                    if lib_dir.exists()
+                        && let Ok(entries) = fs::read_dir(&lib_dir)
+                    {
+                        for entry in entries.flatten() {
+                            let fname = entry.file_name();
+                            if fname.to_string_lossy().starts_with("python") {
+                                let site_packages = entry.path().join("site-packages");
+                                if site_packages.exists() {
+                                    search_roots.push(site_packages);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+                path = parent.to_path_buf();
+            }
+        }
+    }
+
+    let parts: Vec<&str> = module.split('.').collect();
+    for root in search_roots {
+        let mut base = root.clone();
+        for part in &parts {
+            base.push(part);
+        }
+        let file_candidate = base.with_extension("py");
+        if file_candidate.exists() {
+            return Some(file_candidate);
+        }
+        let init_candidate = base.join("__init__.py");
+        if init_candidate.exists() {
+            return Some(init_candidate);
+        }
+        if let Some(root_name) = root.file_name()
+            && root_name
+                == parts
+                    .first()
+                    .map(std::ffi::OsStr::new)
+                    .unwrap_or_else(|| std::ffi::OsStr::new(""))
+            && parts.len() > 1
+        {
+            let mut nested_base = root.clone();
+            for part in parts.iter().skip(1) {
+                nested_base.push(part);
+            }
+            let file_candidate = nested_base.with_extension("py");
+            if file_candidate.exists() {
+                return Some(file_candidate);
+            }
+            let init_candidate = nested_base.join("__init__.py");
+            if init_candidate.exists() {
+                return Some(init_candidate);
+            }
+        }
+        let mut relative = PathBuf::new();
+        for part in &parts {
+            relative.push(part);
+        }
+        if let Some(found) = find_module_path_recursively(&root, &relative.with_extension("py")) {
+            return Some(found);
+        }
+        if let Some(found) = find_module_path_recursively(&root, &relative.join("__init__.py")) {
+            return Some(found);
+        }
+    }
+    None
+}

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -581,12 +581,11 @@ fn resolve_module_path(
     }
 
     if let Ok(path_var) = std::env::var("PATH") {
-        for entry in path_var.split(':') {
-            if !entry.contains(".venv") {
+        for mut path_entry in std::env::split_paths(&path_var) {
+            if !path_entry.to_string_lossy().contains(".venv") {
                 continue;
             }
-            let mut path = PathBuf::from(entry);
-            while let Some(parent) = path.parent() {
+            while let Some(parent) = path_entry.parent() {
                 if let Some(name) = parent.file_name()
                     && name.to_string_lossy().contains(".venv")
                 {
@@ -610,7 +609,7 @@ fn resolve_module_path(
                     }
                     break;
                 }
-                path = parent.to_path_buf();
+                path_entry = parent.to_path_buf();
             }
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -83,7 +83,9 @@ fn is_hover_dtype(src: &str, analysis: &Analysis, pat: &str, expected_dtype: &st
             line: line_idx,
             character: col_idx,
         })
-        .unwrap_or_else(|| panic!("Hover info failed for pat {pat} with expected dtype {expected_dtype}"));
+        .unwrap_or_else(|| {
+            panic!("Hover info failed for pat {pat} with expected dtype {expected_dtype}")
+        });
     let dtype = hover
         .shape
         .as_ref()

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -1,3 +1,6 @@
+use shapels::analyze_source_at_path;
+use std::path::Path;
+
 use crate::analyze_source;
 use crate::tests::{extract_test_case, is_hover_expected};
 
@@ -74,7 +77,7 @@ fn inference_propages_through_method() {
 #[test]
 fn method_improper_is_resolved_to_its_forward_tuple_type_hints() {
     let src = extract_test_case(PY_DATA, 9);
-    let analysis = analyze_source(&src);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert!(is_hover_expected(&src, &analysis, "output,", "B X R"));
     assert!(is_hover_expected(&src, &analysis, "output2 =", "B O T"));
 }
@@ -82,21 +85,21 @@ fn method_improper_is_resolved_to_its_forward_tuple_type_hints() {
 #[test]
 fn inference_propagates_to_self() {
     let src = extract_test_case(PY_DATA, 10);
-    let analysis = analyze_source(&src);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert!(is_hover_expected(&src, &analysis, "z =", "B X Z"));
 }
 
 #[test]
 fn inference_propagates_to_nested_self() {
     let src = extract_test_case(PY_DATA, 11);
-    let analysis = analyze_source(&src);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert!(is_hover_expected(&src, &analysis, "z =", "B X L"));
 }
 
 #[test]
 fn inference_propagates_to_annotated_self() {
     let src = extract_test_case(PY_DATA, 12);
-    let analysis = analyze_source(&src);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert_eq!(analysis.diagnostics.len(), 0);
     assert!(is_hover_expected(&src, &analysis, "z =", "B A A"));
 }

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -78,3 +78,32 @@ fn method_improper_is_resolved_to_its_forward_tuple_type_hints() {
     assert!(is_hover_expected(&src, &analysis, "output,", "B X R"));
     assert!(is_hover_expected(&src, &analysis, "output2 =", "B O T"));
 }
+
+#[test]
+fn inference_propagates_to_self() {
+    let src = extract_test_case(PY_DATA, 10);
+    let analysis = analyze_source(&src);
+    assert!(is_hover_expected(&src, &analysis, "z =", "B X Z"));
+}
+
+#[test]
+fn inference_propagates_to_nested_self() {
+    let src = extract_test_case(PY_DATA, 11);
+    let analysis = analyze_source(&src);
+    assert!(is_hover_expected(&src, &analysis, "z =", "B X L"));
+}
+
+#[test]
+fn inference_propagates_to_annotated_self() {
+    let src = extract_test_case(PY_DATA, 12);
+    let analysis = analyze_source(&src);
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "z =", "B A A"));
+}
+
+#[test]
+fn inference_emits_diagnostics_on_unknown_self() {
+    let src = extract_test_case(PY_DATA, 13);
+    let analysis = analyze_source(&src);
+    assert!(analysis.diagnostics.len() > 0);
+}

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -110,3 +110,60 @@ fn inference_emits_diagnostics_on_unknown_self() {
     let analysis = analyze_source(&src);
     assert!(analysis.diagnostics.len() > 0);
 }
+
+#[test]
+fn concrete_parameter_is_properly_multiplied() {
+    let src = extract_test_case(PY_DATA, 14);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "out =", "B X 57"));
+}
+
+#[test]
+fn abstract_parameter_is_properly_multiplied() {
+    let src = extract_test_case(PY_DATA, 15);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "out =", "B X 1"));
+}
+
+#[test]
+fn abstract_parameter_emits_diag_with_wrong_shape() {
+    let src = extract_test_case(PY_DATA, 16);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert!(analysis.diagnostics.len() > 0);
+}
+
+#[test]
+fn self_tensor_is_properly_multiplied() {
+    let src = extract_test_case(PY_DATA, 17);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "out =", "B X U"));
+}
+
+#[test]
+fn self_tensor_is_properly_registered_after_ops() {
+    let src = extract_test_case(PY_DATA, 18);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "out =", "B X 1"));
+}
+
+#[test]
+fn self_param_is_properly_registered_after_ops() {
+    let src = extract_test_case(PY_DATA, 19);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "self.my_param =", "S W"));
+    assert!(is_hover_expected(&src, &analysis, "out =", "B X W"));
+}
+
+#[test]
+fn self_param_is_properly_reassigned() {
+    let src = extract_test_case(PY_DATA, 20);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "my_tensor =", "S T"));
+    assert!(is_hover_expected(&src, &analysis, "out =", "B X T"));
+}

--- a/src/tests/test_multifile.rs
+++ b/src/tests/test_multifile.rs
@@ -1,10 +1,12 @@
 //! Tests multifile support using .venv files and relative paths at test_data/multi*.py
 
-use shapels::analyze_file;
-use std::path::Path;
+use shapels::{ModuleCache, analyze_file, analyze_source_at_path_with_cache};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::analyze_source_at_path;
 use crate::tests::{extract_test_case, is_hover_dtype, is_hover_expected};
+use shapels::analyze_source_at_path;
 
 const PY_MULTI_CALLER: &str = include_str!("../../test_data/multi_caller.py");
 const PY_REPRO: &str = include_str!("../../test_data/import_callee.py");
@@ -138,4 +140,82 @@ fn imported_function_does_not_show_diagnostic_on_callee() {
     // no diagnostics expected
     println!("{:?}", analysis.diagnostics);
     assert_eq!(analysis.diagnostics.len(), 0);
+}
+
+#[test]
+fn persistent_module_cache_reloads_changed_imported_self_attr_refs() {
+    let temp_dir = temp_test_dir("cache-invalidation");
+    let caller_path = temp_dir.join("caller.py");
+    let callee_path = temp_dir.join("imported.py");
+
+    fs::write(&callee_path, imported_module_source("First")).expect("write initial callee");
+    fs::write(&caller_path, caller_module_source()).expect("write caller");
+
+    let caller_src = fs::read_to_string(&caller_path).expect("read caller");
+    let mut cache = ModuleCache::new();
+
+    let analysis = analyze_source_at_path_with_cache(&caller_src, &caller_path, &mut cache);
+    assert!(is_hover_expected(&caller_src, &analysis, "z =", "B X O"));
+
+    cache.update_file_source(&callee_path, imported_module_source("Second"));
+
+    let updated = analyze_source_at_path_with_cache(&caller_src, &caller_path, &mut cache);
+    assert!(is_hover_expected(&caller_src, &updated, "z =", "B X P"));
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+fn temp_test_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("shapels-{prefix}-{nanos}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn caller_module_source() -> String {
+    r#"
+import torch
+from imported import Outer
+
+
+def run():
+    B, X, R = 2, 3, 5
+    x = torch.zeros(B, X, R)
+    model = Outer()
+    z = model(x)
+"#
+    .trim_start()
+    .to_string()
+}
+
+fn imported_module_source(proj_class: &str) -> String {
+    format!(
+        r#"
+import torch
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+
+class First(torch.nn.Module):
+    def forward(self, x: F[T, "B X R"]) -> F[T, "B X O"]:
+        return x
+
+
+class Second(torch.nn.Module):
+    def forward(self, x: F[T, "B X R"]) -> F[T, "B X P"]:
+        return x
+
+
+class Outer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = {proj_class}()
+
+    def forward(self, x: F[T, "B X R"]):
+        return self.proj(x)
+"#
+    )
 }

--- a/src/tests/test_multiply.rs
+++ b/src/tests/test_multiply.rs
@@ -251,7 +251,9 @@ fn equality_operators_always_return_bool() {
                 line: line_idx,
                 character: col_idx,
             })
-            .unwrap_or_else(|| panic!("Hover info failed for pat {pattern} with expected shape {expected}"));
+            .unwrap_or_else(|| {
+                panic!("Hover info failed for pat {pattern} with expected shape {expected}")
+            });
         let shape = hover.shape.as_ref().unwrap();
         assert_eq!(shape.dim_string(), "A B C 1");
         assert_eq!(shape.dtype.as_deref(), Some("bool"));

--- a/src/tests/test_shape_assign.rs
+++ b/src/tests/test_shape_assign.rs
@@ -79,7 +79,9 @@ fn test_zeros_creation_size() {
             line: line_idx,
             character: col_idx,
         })
-        .unwrap_or_else(|| panic!("Hover info failed for pat {pat} with expected shape {expected}"));
+        .unwrap_or_else(|| {
+            panic!("Hover info failed for pat {pat} with expected shape {expected}")
+        });
     let shape = hover.shape.as_ref().unwrap();
     assert_eq!(shape.dim_string(), expected);
     assert_eq!(shape.dtype, Some(String::from("bool")));

--- a/test_data/class.py
+++ b/test_data/class.py
@@ -248,5 +248,5 @@ class MyModelNestedNoSelf(torch.nn.Module):
     def forward(x: F[T, "B A X"], y: F[T, "A X"]) -> tuple[F[T, "B A A"], F[T, "B X A"]]:
         # should emit a diagnostic, self unknown
         w = self.proj(x, y.T)
-        return z, y
+        return w, y
 

--- a/test_data/class.py
+++ b/test_data/class.py
@@ -159,3 +159,94 @@ def inference_shorcircuits_through_method_callee_type_hints():
     x: F[T, "B X R"] = torch.ones(B, X, R)
     linear = UserLinearWithWrongMethod()
     output, output2 = linear.ones_from_input(x)
+
+
+# test 10
+import torch
+from multi_callee import UserLinear
+
+
+class MyModel(torch.nn.Module):
+    def __init__(self):
+        self.proj = UserLinear()
+
+    def forward(self, x, y):
+        B, X, Y = x.shape
+        Y, Z = y.shape
+        z = self.proj(x, y)
+        return z
+
+
+# test 11
+from multi_callee import UserLinear
+
+
+class MyModelNested(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+
+    def forward(self, x, y):
+        z = self.proj(x, y)
+        return z.T
+
+
+class MyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = MyModelNested()
+
+    def forward(self, x, y):
+        B, X, U = x.shape
+        U, L = y.shape
+        z = self.proj(x, y)
+        return z
+
+
+# test 12
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+
+
+class MyModelNested(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+
+    def forward(self, x: F[T, "B A X"], y: F[T, "A X"]) -> tuple[F[T, "B A A"], F[T, "B X A"]]:
+        z = self.proj(x, y.T)
+        return z, y
+
+
+class MyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = MyModelNested()
+
+    def forward(self, x, y):
+        z, u = self.proj(x, y)
+        return z.T
+
+    def another_method(self, x: F[T, "B A X"], y: F[T, "A X"]):
+        z, u = self.proj(x, y)
+        x = z.view(1, 0, 2)
+        return x
+
+
+# test 13
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+
+
+class MyModelNestedNoSelf(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+
+    def forward(x: F[T, "B A X"], y: F[T, "A X"]) -> tuple[F[T, "B A A"], F[T, "B X A"]]:
+        # should emit a diagnostic, self unknown
+        w = self.proj(x, y.T)
+        return z, y
+

--- a/test_data/class.py
+++ b/test_data/class.py
@@ -250,3 +250,141 @@ class MyModelNestedNoSelf(torch.nn.Module):
         w = self.proj(x, y.T)
         return w, y
 
+# test 14
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+import torch.nn as nn
+
+
+class MyModelNestedParamConcrete(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        self.p = nn.Parameter(torch.ones(32, 57))
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        # annotating to rename from concrete to abstract dimensions
+        self.p: F[T, "S 57"]
+        out = w @ self.p
+        return w, y
+
+
+# test 15
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+
+
+class MyModelNestedParamAbstract(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        S, U = 32, 2
+        self.pos_emb = torch.nn.Parameter(torch.Tensor(S, U))
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        out = w @ self.pos_emb.sum(dim=1).unsqueeze(1)
+        return w, y
+
+# test 16
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+import torch.nn as nn
+
+
+class MyModelNestedParamAbstractWrong(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        L, U = 32, 2
+        self.pos_emb = nn.Parameter(torch.Tensor(L, U))
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        # should emit diagnostic, S != L
+        out = w @ self.pos_emb
+        return w, y
+
+
+# test 17
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+
+
+class MyModelNestedTensorAbstract(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        S, U = 32, 2
+        self.some_tensor = torch.zeros(S, U)
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        out = w @ self.some_tensor
+        return w, y
+
+
+# test 18
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+
+
+class MyModelNestedTensorAbstractOps(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        S, U = 32, 2
+        self.some_tensor = torch.Tensor(S, U).sum(dim=-1, keepdim=True)
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        out = w @ self.some_tensor
+        return w, y
+
+
+# test 19
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+
+
+class MyModelNestedParameterAbstractOps(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        S, W = 32, 2
+        self.my_param = torch.nn.Parameter(torch.ones(W, S).permute(1, 0))
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        out = w @ self.my_param
+        return w, y
+
+
+# test 20
+from torch import Tensor as T
+from jaxtyping import Float as F
+from multi_callee import UserLinear
+import torch.nn as nn
+
+
+class MyModelNestedParameterAbstractReassigned(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = UserLinear()
+        S, T = 32, 2
+        self.some_param = nn.Parameter(torch.Tensor(T, S).permute(1, 0))
+
+    def forward(self, x: F[T, "B X A"], y: F[T, "S A"]) -> tuple[F[T, "B X S"], F[T, "S A"]]:
+        w = self.proj(x, y.T)
+        my_tensor = self.some_param
+        out = w @ my_tensor
+        return w, y
+
+

--- a/test_data/unet.py
+++ b/test_data/unet.py
@@ -1,0 +1,165 @@
+"""Example file, implementing a more or less modern Unet."""
+
+import logging
+from math import ceil
+
+import torch
+import torch.nn as nn
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+
+def _round_filters(filters: int, factor: float, divisor: int = 8, min_depth: int | None = None) -> int:
+    if factor == 1.0:
+        return filters
+    min_depth = min_depth or divisor
+    v = filters * factor
+    new_v = max(min_depth, int(v + divisor / 2) // divisor * divisor)
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return int(new_v)
+
+
+def _round_repeats(repeats: int, factor: float) -> int:
+    if factor == 1.0:
+        return repeats
+    return int(ceil(repeats * factor))
+
+
+class ConvBNAct(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        groups: int = 1,
+        act: bool = True,
+    ):
+        super().__init__()
+        padding = kernel_size // 2
+        self.net = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size, stride=stride, padding=padding, groups=groups, bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.SiLU() if act else nn.Identity(),
+        )
+
+    def forward(self, x: F[T, "B C H W"]) -> F[T, "B C2 H2 W2"]:
+        return self.net(x)
+
+
+class SqueezeExcite(nn.Module):
+    """Per-channel learned scaling of the input tensor.
+
+    Ref: [Hu et al., 2019](http://arxiv.org/abs/1709.01507)
+    """
+    def __init__(self, channels: int, se_ratio: float = 0.25):
+        super().__init__()
+        reduced = max(8, int(channels * se_ratio))
+        self.net = nn.Sequential(
+            nn.AdaptiveAvgPool2d(1),
+            nn.Conv2d(channels, reduced, kernel_size=1),
+            nn.SiLU(),
+            nn.Conv2d(reduced, channels, kernel_size=1),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x: F[T, "B C H W"]) -> F[T, "B C H W"]:
+        return x * self.net(x)
+
+
+class MBConv(nn.Module):
+    """MobileConvNet block [Sandler et al., 2018](https://doi.org/10.1109/CVPR.2018.00474)."""
+    def __init__(self, in_channels: int, out_channels: int, expand_ratio: int = 4, se_ratio: float = 0.25):
+        super().__init__()
+        mid = int(in_channels * expand_ratio)
+        self.use_res = in_channels == out_channels
+
+        self.net = nn.Sequential(
+            ConvBNAct(in_channels, mid, kernel_size=1, act=True) if expand_ratio != 1 else nn.Identity(),
+            ConvBNAct(mid, mid, kernel_size=3, groups=mid, act=True),
+            SqueezeExcite(mid, se_ratio=se_ratio),
+            ConvBNAct(mid, out_channels, kernel_size=1, act=False),
+        )
+
+    def forward(self, x: F[T, "B C H W"]) -> F[T, "B C2 H W"]:
+        y = self.net(x)
+        return y + x if self.use_res else y
+
+
+def _mbconv_stage(in_channels: int, out_channels: int, repeats: int, expand_ratio: int = 4, se_ratio: float = 0.25):
+    return nn.Sequential(
+        *[
+            MBConv(in_channels if i == 0 else out_channels, out_channels, expand_ratio=expand_ratio, se_ratio=se_ratio)
+            for i in range(repeats)
+        ]
+    )
+
+
+class Unet(nn.Module):
+    """Efficient-Unet ([Tan and Le, 2020](http://arxiv.org/abs/1905.11946)) for segmentation, optionally integrates embeddings in the bottleneck."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        factor: float = 1.0,
+        pools: tuple[int, int] = (7, 2),
+    ):
+        super().__init__()
+
+        base_hidden = (64, 128, 256)
+        hidden = tuple(_round_filters(h, factor) for h in base_hidden)
+        base_repeats = (2, 2, 3)
+        repeats = tuple(_round_repeats(r, factor) for r in base_repeats)
+
+        # down-sampling (encoder) path
+        self.down1 = _mbconv_stage(in_channels, hidden[0], repeats=repeats[0], expand_ratio=4, se_ratio=0.25)
+        self.down2 = _mbconv_stage(hidden[0], hidden[1], repeats=repeats[1], expand_ratio=4, se_ratio=0.25)
+        self.down3 = _mbconv_stage(hidden[1], hidden[2], repeats=repeats[2], expand_ratio=4, se_ratio=0.25)
+        self.pool1 = nn.MaxPool2d(kernel_size=pools[0], stride=pools[0])
+        self.pool2 = nn.MaxPool2d(kernel_size=pools[1], stride=pools[1])
+
+        # up-sampling (decoder) path
+        self.up_trans1 = nn.ConvTranspose2d(hidden[2], hidden[1], kernel_size=pools[1], stride=pools[1])
+        self.conv_up1 = _mbconv_stage(hidden[1] + hidden[1], hidden[1], repeats=_round_repeats(2, factor), expand_ratio=4, se_ratio=0.25)
+
+        self.up_trans2 = nn.ConvTranspose2d(hidden[1], hidden[0], kernel_size=pools[0], stride=pools[0])
+        self.conv_up2 = _mbconv_stage(hidden[0] + hidden[0], hidden[0], repeats=_round_repeats(2, factor), expand_ratio=4, se_ratio=0.25)
+
+        # 1×1 conv to get a single output channel (segmentation target)
+        self.out_conv = nn.Conv2d(hidden[0], 1, kernel_size=1)
+
+    def forward(self, x: F[T, "B C H W"]) -> F[T, "B H W"]:
+        """Forward patches, integrating information from the FM embeddings.
+
+        Args:
+            x(torch.Tensor, [Batch, Channels, Height, Width]): batch instance
+            embeddings(torch.Tensor, [B, Height_2, Width_2, Emb]): embeddings from
+                foundational model. If `None`, they are not used.
+        """
+        # Encoder
+        c1 = self.down1(x)  # shape: (B, H1, H, W)
+        p1 = self.pool1(c1)  # shape: (B, H1, H/2, W/2)
+        c2 = self.down2(p1)  # shape: (B, H2, H/2, W/2)
+        p2 = self.pool2(c2)  # shape: (B, H2, H/4, W/4)
+        c3 = self.down3(p2)  # shape: (B, H3, H/4, W/4)
+
+        # Decoder, with residual connections to the corresponding encoder steps
+        u1 = self.up_trans1(c3)  # upsample to (B, H2, H/2, W/2)
+        u1 = torch.cat([u1, c2], dim=1)  # shape: (B, H2+H2, H/2, W/2)
+        u1 = self.conv_up1(u1)  # shape: (B, H2, H/2, W/2)
+        u2 = self.up_trans2(u1)  # upsample to (B, H1, H, W)
+        u2 = torch.cat([u2, c1], dim=1)  # shape: (B, H1+H1, H, W)
+        u2 = self.conv_up2(u2)  # shape: (B, H1, H, W)
+
+        return self.out_conv(u2).squeeze(1)
+
+    def count_parameters(self):
+        total_params = 0
+        for _, param in self.named_parameters():
+            if param.requires_grad:
+                total_params += param.numel()
+        return total_params


### PR DESCRIPTION
Related to #3 

### Description

This PR implements `self.*` resolution inside a class. Native torch modules such as `torch.nn.Linear` or `torch.nn.Sequential` are not part of this PR.

### Implementation

No new support for `torch.nn` has been added, it's just storing a cache of the declared `self.*` assignments in the `__init__` method inside simulated classes. If the right size is a known module (imported, or present in the file, `UserLinear` below), it will be tracked in the information associated with that class (`MyModel`).

Below, during inference of the forward method, `self.proj` will be looked up in the gathered information about the class (`ModuleCache`) and resolved to `UserLinear.forward` to infer the shape of `z`.

```python
import torch
from multi_callee import UserLinear


class MyModel(torch.nn.Module):
    def __init__(self):
        self.proj = UserLinear()

    def forward(self, x, y):
        B, X, Y = x.shape
        Y, Z = y.shape
        z = self.proj(x, y)
        return z
```