### PR TITLE
Inference of built-in `torch.nn.Module`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ bench = false
 [[bench]]
 name = "bench_selected_tests"
 harness = false
+
+[[bench]]
+name = "bench_macro_lsp"
+harness = false

--- a/benches/bench_macro_lsp.rs
+++ b/benches/bench_macro_lsp.rs
@@ -1,0 +1,71 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use shapels::{ModuleCache, analyze_file_with_cache, analyze_source_at_path_with_cache};
+use std::hint::black_box;
+use std::path::Path;
+
+const MODEL_SRC: &str = include_str!("../test_data/bench_lsp/model.py");
+const MODEL_ALT_SRC: &str = include_str!("../test_data/bench_lsp/model_alt.py");
+const BLOCKS_SRC: &str = include_str!("../test_data/bench_lsp/blocks.py");
+const BLOCKS_ALT_SRC: &str = include_str!("../test_data/bench_lsp/blocks_alt.py");
+
+fn warm_cached_workspace(c: &mut Criterion) {
+    let path = Path::new("test_data/bench_lsp/model.py");
+    let mut cache = ModuleCache::new();
+
+    let _ = analyze_file_with_cache(path, &mut cache);
+
+    c.bench_function("MacroWarmCache", |b| {
+        b.iter(|| black_box(analyze_file_with_cache(path, &mut cache).diagnostics.len()))
+    });
+}
+
+fn imported_module_invalidation(c: &mut Criterion) {
+    let caller_path = Path::new("test_data/bench_lsp/model.py");
+    let blocks_path = Path::new("test_data/bench_lsp/blocks.py");
+    let mut cache = ModuleCache::new();
+    let mut use_alt = false;
+
+    let _ = analyze_source_at_path_with_cache(MODEL_SRC, caller_path, &mut cache);
+
+    c.bench_function("MacroImportInvalidation", |b| {
+        b.iter(|| {
+            use_alt = !use_alt;
+            let next = if use_alt { BLOCKS_ALT_SRC } else { BLOCKS_SRC };
+            cache.update_file_source(blocks_path, next.to_string());
+            black_box(
+                analyze_source_at_path_with_cache(MODEL_SRC, caller_path, &mut cache)
+                    .diagnostics
+                    .len(),
+            )
+        })
+    });
+}
+
+fn caller_edit_warm_cache(c: &mut Criterion) {
+    let caller_path = Path::new("test_data/bench_lsp/model.py");
+    let mut cache = ModuleCache::new();
+    let mut use_alt = false;
+
+    let _ = analyze_source_at_path_with_cache(MODEL_SRC, caller_path, &mut cache);
+
+    c.bench_function("MacroCallerEditWarm", |b| {
+        b.iter(|| {
+            use_alt = !use_alt;
+            let next = if use_alt { MODEL_ALT_SRC } else { MODEL_SRC };
+            cache.update_file_source(caller_path, next.to_string());
+            black_box(
+                analyze_source_at_path_with_cache(next, caller_path, &mut cache)
+                    .diagnostics
+                    .len(),
+            )
+        })
+    });
+}
+
+criterion_group!(
+    macro_lsp_benches,
+    warm_cached_workspace,
+    imported_module_invalidation,
+    caller_edit_warm_cache
+);
+criterion_main!(macro_lsp_benches);

--- a/src/expr_tokens.rs
+++ b/src/expr_tokens.rs
@@ -1,0 +1,148 @@
+//! Shared parsing of small symbolic expressions into token strings.
+
+use rustpython_parser::ast::{Constant, Expr, Operator};
+use std::borrow::Cow;
+
+/// Toggle which expression forms may be collapsed into a symbolic token.
+#[derive(Clone, Copy)]
+pub(crate) struct ExprTokenOptions {
+    pub(crate) allow_string_literals: bool,
+    pub(crate) allow_attributes: bool,
+    pub(crate) allow_add_sub: bool,
+    pub(crate) allow_mul: bool,
+    pub(crate) allow_div: bool,
+    pub(crate) allow_int_cast: bool,
+}
+
+/// Conservative dim parsing used by variadic shape arguments (used at [`crate::infer`]).
+pub(crate) const DIM_TOKEN_OPTIONS: ExprTokenOptions = ExprTokenOptions {
+    allow_string_literals: false,
+    allow_attributes: false,
+    allow_add_sub: false,
+    allow_mul: true,
+    allow_div: false,
+    allow_int_cast: false,
+};
+
+/// Broader parsing used for builtin module constructor arguments (used at [`crate::torch_nn`]).
+///
+/// Builtin `torch.nn` modules often accept symbolic scalar expressions, tuple
+/// members, attribute leaves such as `dtype`, and trivial `int(...)` wrappers.
+pub(crate) const MODULE_ARG_TOKEN_OPTIONS: ExprTokenOptions = ExprTokenOptions {
+    allow_string_literals: true,
+    allow_attributes: true,
+    allow_add_sub: true,
+    allow_mul: true,
+    allow_div: true,
+    allow_int_cast: true,
+};
+
+/// Token parsing for conv stride/padding/dilation style arguments.
+///
+/// These parameters are scalar-or-tuple numeric expressions, so string literals
+/// and plain attribute leaves stay disabled even though module constructor
+/// parsing is otherwise broader.
+pub(crate) const CONV_PARAM_TOKEN_OPTIONS: ExprTokenOptions = ExprTokenOptions {
+    allow_string_literals: false,
+    allow_attributes: false,
+    allow_add_sub: true,
+    allow_mul: true,
+    allow_div: true,
+    allow_int_cast: true,
+};
+
+/// Minimal scalar parsing for slice bounds before falling back to raw source.
+///
+/// Slice expressions preserve arbitrary source text as a last resort, so this
+/// preset only recognizes the simple scalar cases that are safe to normalize.
+pub(crate) const SLICE_BOUND_TOKEN_OPTIONS: ExprTokenOptions = ExprTokenOptions {
+    allow_string_literals: false,
+    allow_attributes: false,
+    allow_add_sub: false,
+    allow_mul: false,
+    allow_div: false,
+    allow_int_cast: true,
+};
+
+/// Convert a scalar expression into a symbolic token according to `options`.
+///
+/// The returned `Cow` borrows where possible to keep the common identifier and
+/// string-literal cases cheap, and allocates only when normalization is needed
+/// (for example `-N` or `A*B`).
+pub(crate) fn expr_to_symbolic_token<'a>(
+    expr: &'a Expr,
+    options: ExprTokenOptions,
+) -> Option<Cow<'a, str>> {
+    match expr {
+        Expr::Name(name) => Some(Cow::Borrowed(name.id.as_str())),
+        Expr::Constant(constant) => match &constant.value {
+            Constant::Int(int) => Some(Cow::Owned(int.to_string())),
+            Constant::Float(float) => Some(Cow::Owned(float.to_string())),
+            Constant::Str(string) if options.allow_string_literals => {
+                Some(Cow::Borrowed(string.as_str()))
+            }
+            _ => None,
+        },
+        Expr::Attribute(attr) if options.allow_attributes => {
+            Some(Cow::Borrowed(attr.attr.as_str()))
+        }
+        Expr::UnaryOp(unary) => match unary.op {
+            rustpython_parser::ast::UnaryOp::USub => {
+                expr_to_symbolic_token(unary.operand.as_ref(), options)
+                    .map(|token| Cow::Owned(format!("-{token}")))
+            }
+            rustpython_parser::ast::UnaryOp::UAdd => {
+                expr_to_symbolic_token(unary.operand.as_ref(), options)
+            }
+            _ => None,
+        },
+        Expr::BinOp(bin) => {
+            let op = match bin.op {
+                Operator::Add if options.allow_add_sub => "+",
+                Operator::Sub if options.allow_add_sub => "-",
+                Operator::Mult if options.allow_mul => "*",
+                Operator::Div | Operator::FloorDiv if options.allow_div => "/",
+                _ => return None,
+            };
+            let left = expr_to_symbolic_token(bin.left.as_ref(), options)?;
+            let right = expr_to_symbolic_token(bin.right.as_ref(), options)?;
+            Some(Cow::Owned(format!("{left}{op}{right}")))
+        }
+        Expr::Call(call) if options.allow_int_cast => {
+            if let Expr::Name(name) = call.func.as_ref()
+                && name.id.as_str() == "int"
+                && call.keywords.is_empty()
+            {
+                return call
+                    .args
+                    .first()
+                    .and_then(|expr| expr_to_symbolic_token(expr, options));
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Parse either a scalar expression or a tuple/list of scalar expressions into
+/// owned token strings.
+pub(crate) fn expr_to_symbolic_tokens(
+    expr: &Expr,
+    options: ExprTokenOptions,
+) -> Option<Vec<String>> {
+    match expr {
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .map(|expr| expr_to_symbolic_token(expr, options).map(Cow::into_owned))
+            .collect(),
+        Expr::List(list) => list
+            .elts
+            .iter()
+            .map(|expr| expr_to_symbolic_token(expr, options).map(Cow::into_owned))
+            .collect(),
+        other => expr_to_symbolic_token(other, options)
+            .map(Cow::into_owned)
+            .map(|token| vec![token]),
+    }
+}

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -2146,6 +2146,163 @@ pub fn infer_range_size(
     }
 }
 
+pub(crate) fn infer_linear_module(
+    mut base: Shape,
+    in_features: Option<&str>,
+    out_features: Option<&str>,
+    range: TextRange,
+    diagnostics: &mut Vec<Diagnostic>,
+    source: &str,
+) -> Option<Shape> {
+    let Some(last_dim) = base.dims.last_mut() else {
+        diagnostics.push(Diagnostic {
+            range: text_range_to_lsp(range, source),
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: None,
+            code_description: None,
+            source: Some("shapels".into()),
+            message: "Input tensor has incorrect dims for Linear".into(),
+            related_information: None,
+            tags: None,
+            data: None,
+        });
+        return None;
+    };
+    if let Some(expected) = in_features
+        && concrete_dim_mismatch(last_dim, expected)
+    {
+        diagnostics.push(Diagnostic {
+            range: text_range_to_lsp(range, source),
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: None,
+            code_description: None,
+            source: Some("shapels".into()),
+            message: format!("Linear input feature mismatch: expected {expected}, got {last_dim}"),
+            related_information: None,
+            tags: None,
+            data: None,
+        });
+    }
+    if let Some(out_features) = out_features {
+        *last_dim = out_features.to_string();
+    }
+    Some(base)
+}
+
+pub(crate) fn infer_batchnorm_module(
+    base: Shape,
+    dims: usize,
+    num_features: Option<&str>,
+    range: TextRange,
+    diagnostics: &mut Vec<Diagnostic>,
+    source: &str,
+) -> Option<Shape> {
+    let rank = base.dims.len();
+    let valid_rank = match dims {
+        1 => matches!(rank, 2 | 3),
+        2 => rank == 4,
+        3 => rank == 5,
+        _ => false,
+    };
+    if !valid_rank {
+        diagnostics.push(Diagnostic {
+            range: text_range_to_lsp(range, source),
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: None,
+            code_description: None,
+            source: Some("shapels".into()),
+            message: format!("Input tensor has incorrect dims for BatchNorm{dims}d"),
+            related_information: None,
+            tags: None,
+            data: None,
+        });
+        return None;
+    }
+    if let Some(expected) = num_features
+        && let Some(channels) = base.dims.get(1)
+        && concrete_dim_mismatch(channels, expected)
+    {
+        diagnostics.push(Diagnostic {
+            range: text_range_to_lsp(range, source),
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: None,
+            code_description: None,
+            source: Some("shapels".into()),
+            message: format!(
+                "BatchNorm{dims}d channel mismatch: expected {expected}, got {channels}"
+            ),
+            related_information: None,
+            tags: None,
+            data: None,
+        });
+    }
+    Some(base)
+}
+
+pub(crate) fn infer_conv_module(
+    base: Shape,
+    conv_dim: usize,
+    in_channels: Option<&str>,
+    out_channels: Option<&str>,
+    kernel_size: &[String],
+    stride: &[String],
+    padding: &[String],
+    dilation: &[String],
+    _groups: Option<&str>,
+    range: TextRange,
+    diagnostics: &mut Vec<Diagnostic>,
+    source: &str,
+) -> Option<Shape> {
+    let input_channel = base
+        .dims
+        .len()
+        .checked_sub(conv_dim)
+        .and_then(|pos| pos.checked_sub(1))
+        .and_then(|idx| base.dims.get(idx))
+        .cloned();
+    if let (Some(current), Some(expected)) = (input_channel.as_deref(), in_channels)
+        && concrete_dim_mismatch(current, expected)
+    {
+        diagnostics.push(Diagnostic {
+            range: text_range_to_lsp(range, source),
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: None,
+            code_description: None,
+            source: Some("shapels".into()),
+            message: format!(
+                "Conv{conv_dim}d channel mismatch: expected {expected}, got {current}"
+            ),
+            related_information: None,
+            tags: None,
+            data: None,
+        });
+    }
+
+    let mut kernel = vec![
+        out_channels
+            .map(str::to_string)
+            .or_else(|| input_channel.clone())
+            .unwrap_or_else(|| "OutChannels".to_string()),
+        in_channels
+            .map(str::to_string)
+            .or(input_channel)
+            .unwrap_or_else(|| "InChannels".to_string()),
+    ];
+    kernel.extend(expand_conv_params(kernel_size, conv_dim, "K"));
+
+    infer_conv_with_params(
+        base,
+        kernel,
+        stride,
+        padding,
+        dilation,
+        conv_dim,
+        range,
+        diagnostics,
+        source,
+    )
+}
+
 pub fn infer_conv(
     base: Shape,
     kernel: Vec<String>,
@@ -2154,10 +2311,45 @@ pub fn infer_conv(
     diagnostics: &mut Vec<Diagnostic>,
     source: &str,
 ) -> Option<Shape> {
+    let stride = get_arg(call, "stride", 3)
+        .and_then(expr_to_tuple)
+        .unwrap_or_default();
+    let padding = get_arg(call, "padding", 4)
+        .and_then(expr_to_tuple)
+        .unwrap_or_default();
+    let dilation = get_arg(call, "dilation", 5)
+        .and_then(expr_to_tuple)
+        .unwrap_or_default();
+    infer_conv_with_params(
+        base,
+        kernel,
+        &stride,
+        &padding,
+        &dilation,
+        conv_dim,
+        call.range,
+        diagnostics,
+        source,
+    )
+}
+
+fn infer_conv_with_params(
+    base: Shape,
+    kernel: Vec<String>,
+    stride: &[String],
+    padding: &[String],
+    dilation: &[String],
+    conv_dim: usize,
+    range: TextRange,
+    diagnostics: &mut Vec<Diagnostic>,
+    source: &str,
+) -> Option<Shape> {
     let n_dims = base.dims.len();
     let n_k_dims = kernel.len();
-    let incorrect_input = n_dims - conv_dim > 2 || n_dims - conv_dim < 1;
-    let incorrect_kernel = n_k_dims - conv_dim > 2 || n_k_dims - conv_dim < 1;
+    let input_extra = n_dims.checked_sub(conv_dim);
+    let kernel_extra = n_k_dims.checked_sub(conv_dim);
+    let incorrect_input = !matches!(input_extra, Some(1 | 2));
+    let incorrect_kernel = !matches!(kernel_extra, Some(1 | 2));
     if incorrect_input || incorrect_kernel {
         let (incorrect_dims, tensor_msg) = if !incorrect_input {
             (n_dims, "Input tensor")
@@ -2165,7 +2357,7 @@ pub fn infer_conv(
             (n_k_dims, "Kernel")
         };
         diagnostics.push(Diagnostic {
-            range: text_range_to_lsp(call.range, source),
+            range: text_range_to_lsp(range, source),
             severity: Some(DiagnosticSeverity::ERROR),
             code: None,
             code_description: None,
@@ -2181,9 +2373,9 @@ pub fn infer_conv(
             data: None,
         });
         return None;
-    } else if (n_k_dims - n_dims) > 1 {
+    } else if n_k_dims > n_dims + 1 {
         diagnostics.push(Diagnostic {
-            range: text_range_to_lsp(call.range, source),
+            range: text_range_to_lsp(range, source),
             severity: Some(DiagnosticSeverity::ERROR),
             code: None,
             code_description: None,
@@ -2198,15 +2390,9 @@ pub fn infer_conv(
         return None;
     }
     let out_channels = &kernel[0];
-    let stride = get_arg(call, "stride", 3)
-        .and_then(expr_to_tuple)
-        .unwrap_or(vec!["1".to_string(); conv_dim]);
-    let padding = get_arg(call, "padding", 4)
-        .and_then(expr_to_tuple)
-        .unwrap_or(vec!["0".to_string(); conv_dim]);
-    let dilation = get_arg(call, "dilation", 5)
-        .and_then(expr_to_tuple)
-        .unwrap_or(vec!["1".to_string(); conv_dim]);
+    let stride = expand_conv_params(stride, conv_dim, "1");
+    let padding = expand_conv_params(padding, conv_dim, "0");
+    let dilation = expand_conv_params(dilation, conv_dim, "1");
     let pos = n_dims - conv_dim;
     Some(Shape {
         dtype: base.dtype,
@@ -2234,7 +2420,12 @@ pub fn infer_conv(
                             (((n + 2 * p - d * (k - 1) - 1) / s) + 1).to_string()
                         }
                         (Err(_), Ok(k), Ok(s), Ok(p), Ok(d)) => {
-                            format!("({dim}+{})/{s}+1", 2 * p - d * (k - 1) - 1)
+                            let offset = 2 * p - d * (k - 1) - 1;
+                            if s == 1 && offset == -1 {
+                                dim.clone()
+                            } else {
+                                format!("({dim}+{offset})/{s}+1")
+                            }
                         }
                         (Ok(n), Ok(k), Err(_), Ok(p), Ok(d)) => {
                             format!("{}/{stride}+1", (n + 2 * p - d * (k - 1) - 1))
@@ -2302,6 +2493,28 @@ fn expr_to_tuple(expr: &Expr) -> Option<Vec<String>> {
                 .collect(),
         ),
         _ => None,
+    }
+}
+
+fn expand_conv_params(values: &[String], conv_dim: usize, default: &str) -> Vec<String> {
+    match values.len() {
+        0 => vec![default.to_string(); conv_dim],
+        1 => vec![values[0].clone(); conv_dim],
+        len if len >= conv_dim => values[..conv_dim].to_vec(),
+        _ => {
+            let mut expanded = values.to_vec();
+            while expanded.len() < conv_dim {
+                expanded.push(values[0].clone());
+            }
+            expanded
+        }
+    }
+}
+
+fn concrete_dim_mismatch(actual: &str, expected: &str) -> bool {
+    match (actual.parse::<i64>(), expected.parse::<i64>()) {
+        (Ok(current), Ok(expected)) => current != expected,
+        _ => false,
     }
 }
 

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -7,6 +7,9 @@
 //! i64 is excessive for operations that relate to the number of dimensions and
 //! not the dimenions themselves. This should be revisited if bugs come.
 #![allow(clippy::too_many_arguments, clippy::needless_option_as_deref)]
+use crate::expr_tokens::{
+    CONV_PARAM_TOKEN_OPTIONS, DIM_TOKEN_OPTIONS, SLICE_BOUND_TOKEN_OPTIONS, expr_to_symbolic_token,
+};
 use crate::op_groups::{BroadcastOp, RangeOps, SimpleDtype, TorchOp};
 use crate::{
     ClassMap, FuncMap, HoverInfo, Imports, ModuleCache, Shape, VarState, expr_text_range, get_arg,
@@ -461,6 +464,7 @@ fn parse_index_kind<'a>(expr: &'a Expr, source: &'a str) -> IndexKind<'a> {
     }
 }
 
+/// Specific to index/permute/transpose/etc. that need negative indexing normalization.
 fn expr_to_int(expr: &Expr, dims_len: Option<usize>) -> Option<i64> {
     match expr {
         Expr::Constant(ExprConstant {
@@ -480,43 +484,19 @@ fn expr_to_int(expr: &Expr, dims_len: Option<usize>) -> Option<i64> {
 }
 
 fn bound_token(expr: &Expr, source: &str) -> String {
-    if let Expr::Call(call) = expr
-        && let Expr::Name(fname) = call.func.as_ref()
-        && fname.id.as_str() == "int"
-        && let Some(arg0) = call.args.first()
-    {
-        return bound_token(arg0, source);
-    }
-    if let Some(tok) = slice_dim_token(expr) {
-        tok
-    } else {
-        let range = expr_text_range(expr);
-        let mut raw = source
-            .get(range.start().to_usize()..range.end().to_usize())
-            .unwrap_or("")
-            .replace(' ', "");
-        while raw.starts_with('(') && raw.ends_with(')') && raw.len() >= 2 {
-            raw = raw[1..raw.len() - 1].to_string();
-        }
-        raw
-    }
-}
-
-fn slice_dim_token(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::Constant(_) | Expr::UnaryOp(_) => expr_to_int(expr, None).map(|x| x.to_string()),
-        Expr::Name(n) => Some(n.id.to_string()),
-        Expr::Call(call) => {
-            if let Expr::Name(fname) = call.func.as_ref()
-                && fname.id.as_str() == "int"
-                && let Some(arg0) = call.args.first()
-            {
-                return slice_dim_token(arg0);
+    expr_to_symbolic_token(expr, SLICE_BOUND_TOKEN_OPTIONS)
+        .map(|token| token.into_owned())
+        .unwrap_or_else(|| {
+            let range = expr_text_range(expr);
+            let mut raw = source
+                .get(range.start().to_usize()..range.end().to_usize())
+                .unwrap_or("")
+                .replace(' ', "");
+            while raw.starts_with('(') && raw.ends_with(')') && raw.len() >= 2 {
+                raw = raw[1..raw.len() - 1].to_string();
             }
-            None
-        }
-        _ => None,
-    }
+            raw
+        })
 }
 
 fn split_primary_offset(tok: &str) -> (String, Option<String>) {
@@ -1786,49 +1766,29 @@ fn expr_to_dim_token<'a>(
     source: &'a str,
     diag_already: &mut bool,
 ) -> Option<Cow<'a, str>> {
+    if let Some(token) = expr_to_symbolic_token(x, DIM_TOKEN_OPTIONS) {
+        return Some(token);
+    }
+
     match x {
-        Expr::Name(name) => Some(Cow::Borrowed(name.id.as_str())),
-        Expr::Constant(constant) => match &constant.value {
-            Constant::Int(int) => Some(Cow::Owned(int.to_string())),
-            // float is needed for ranges' steps but it's not valid for most dims
-            Constant::Float(float) => Some(Cow::Owned(float.to_string())),
-            _ => {
-                if !*diag_already {
-                    diagnostics.push(Diagnostic {
-                        range: text_range_to_lsp(constant.range, source),
-                        severity: Some(DiagnosticSeverity::INFORMATION),
-                        code: None,
-                        code_description: None,
-                        source: Some("shapels".into()),
-                        message: "Dim was not understood from this argument".into(),
-                        related_information: None,
-                        tags: None,
-                        data: None,
-                    });
-                    *diag_already = true;
-                }
-                None
+        Expr::Constant(constant) => {
+            if !*diag_already {
+                diagnostics.push(Diagnostic {
+                    range: text_range_to_lsp(constant.range, source),
+                    severity: Some(DiagnosticSeverity::INFORMATION),
+                    code: None,
+                    code_description: None,
+                    source: Some("shapels".into()),
+                    message: "Dim was not understood from this argument".into(),
+                    related_information: None,
+                    tags: None,
+                    data: None,
+                });
+                *diag_already = true;
             }
-        },
-        Expr::BinOp(bin) => {
-            if matches!(bin.op, Operator::Mult) {
-                let l = expr_to_dim_token(&bin.left, vars, diagnostics, source, diag_already)?;
-                let r = expr_to_dim_token(&bin.right, vars, diagnostics, source, diag_already)?;
-                Some(Cow::Owned(format!("{l}*{r}")))
-            } else {
-                None
-            }
+            None
         }
-        Expr::UnaryOp(u) => match u.op {
-            ast::UnaryOp::USub => {
-                expr_to_dim_token(u.operand.as_ref(), vars, diagnostics, source, diag_already)
-                    .map(|s| Cow::Owned(format!("-{s}")))
-            }
-            ast::UnaryOp::UAdd => {
-                expr_to_dim_token(u.operand.as_ref(), vars, diagnostics, source, diag_already)
-            }
-            _ => None,
-        },
+        Expr::BinOp(_) | Expr::UnaryOp(_) => None,
         // e.g., torch.zeros(x.shape[int])
         Expr::Subscript(ExprSubscript { value, slice, .. }) => {
             if let (Expr::Attribute(attr), Expr::Constant(c)) = (value.as_ref(), slice.as_ref())
@@ -2463,36 +2423,30 @@ fn infer_conv_with_params(
     })
 }
 
-// TODO(carrascomj): make this more robust by piggybacking on expr_to_dim_token
 fn expr_to_tuple(expr: &Expr) -> Option<Vec<String>> {
     match expr {
-        Expr::Name(n) => Some(vec![n.id.to_string()]),
-        Expr::Constant(c) => match &c.value {
-            ast::Constant::Int(i) => Some(vec![i.to_string()]),
-            _ => None,
-        },
-        Expr::UnaryOp(unary) => {
-            if matches!(unary.op, ast::UnaryOp::USub) {
-                expr_to_tuple(&unary.operand)
-                    .map(|vals| vals.into_iter().map(|v| format!("-{v}")).collect())
-            } else {
-                None
-            }
-        }
         Expr::Tuple(tup) => Some(
             tup.elts
                 .iter()
-                .map(|x| match x {
-                    Expr::Constant(c) => match &c.value {
-                        ast::Constant::Int(i) => i.to_string(),
-                        _ => "".to_string(),
-                    },
-                    Expr::Name(n) => n.id.to_string(),
-                    _ => "".to_string(),
+                .map(|expr| {
+                    expr_to_symbolic_token(expr, CONV_PARAM_TOKEN_OPTIONS)
+                        .map(|token| token.into_owned())
+                        .unwrap_or_default()
                 })
                 .collect(),
         ),
-        _ => None,
+        Expr::List(list) => Some(
+            list.elts
+                .iter()
+                .map(|expr| {
+                    expr_to_symbolic_token(expr, CONV_PARAM_TOKEN_OPTIONS)
+                        .map(|token| token.into_owned())
+                        .unwrap_or_default()
+                })
+                .collect(),
+        ),
+        other => expr_to_symbolic_token(other, CONV_PARAM_TOKEN_OPTIONS)
+            .map(|token| vec![token.into_owned()]),
     }
 }
 

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -2241,7 +2241,6 @@ pub(crate) fn infer_conv_module(
     let mut kernel = vec![
         out_channels
             .map(str::to_string)
-            .or_else(|| input_channel.clone())
             .unwrap_or_else(|| "OutChannels".to_string()),
         in_channels
             .map(str::to_string)
@@ -2424,30 +2423,20 @@ fn infer_conv_with_params(
 }
 
 fn expr_to_tuple(expr: &Expr) -> Option<Vec<String>> {
-    match expr {
-        Expr::Tuple(tup) => Some(
-            tup.elts
-                .iter()
-                .map(|expr| {
-                    expr_to_symbolic_token(expr, CONV_PARAM_TOKEN_OPTIONS)
-                        .map(|token| token.into_owned())
-                        .unwrap_or_default()
-                })
-                .collect(),
-        ),
-        Expr::List(list) => Some(
-            list.elts
-                .iter()
-                .map(|expr| {
-                    expr_to_symbolic_token(expr, CONV_PARAM_TOKEN_OPTIONS)
-                        .map(|token| token.into_owned())
-                        .unwrap_or_default()
-                })
-                .collect(),
-        ),
-        other => expr_to_symbolic_token(other, CONV_PARAM_TOKEN_OPTIONS)
-            .map(|token| vec![token.into_owned()]),
-    }
+    let elts = match expr {
+        Expr::Tuple(tup) => &tup.elts,
+        Expr::List(list) => &list.elts,
+        other => {
+            return expr_to_symbolic_token(other, CONV_PARAM_TOKEN_OPTIONS)
+                .map(|token| vec![token.into_owned()]);
+        }
+    };
+
+    elts.iter()
+        .map(|expr| {
+            expr_to_symbolic_token(expr, CONV_PARAM_TOKEN_OPTIONS).map(|token| token.into_owned())
+        })
+        .collect()
 }
 
 fn expand_conv_params(values: &[String], conv_dim: usize, default: &str) -> Vec<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -739,6 +739,7 @@ fn simulate_block(
                             func_map,
                             imports,
                             class_map,
+                            diagnostics,
                             module_cache.as_deref_mut(),
                             module_path,
                         )
@@ -842,6 +843,7 @@ fn simulate_block(
                         func_map,
                         imports,
                         class_map,
+                        diagnostics,
                         module_cache.as_deref_mut(),
                         module_path,
                     ) {
@@ -1276,6 +1278,7 @@ pub(crate) fn infer_expr_shape(
                     func_map,
                     imports,
                     class_map,
+                    diagnostics,
                     module_cache.as_deref_mut(),
                     module_path,
                 ) && let Some(ret) = infer_module_call_return(
@@ -1419,6 +1422,7 @@ pub(crate) fn infer_expr_shape(
                     func_map,
                     imports,
                     class_map,
+                    diagnostics,
                     module_cache.as_deref_mut(),
                     module_path,
                 ) && let Some(ret) = infer_module_call_return(
@@ -1479,6 +1483,7 @@ pub(crate) fn infer_expr_shape(
                     func_map,
                     imports,
                     class_map,
+                    diagnostics,
                     module_cache.as_deref_mut(),
                     module_path,
                 ) && let Some(ret) = infer_module_call_return(
@@ -1508,6 +1513,7 @@ pub(crate) fn infer_expr_shape(
                 func_map,
                 imports,
                 class_map,
+                diagnostics,
                 module_cache.as_deref_mut(),
                 module_path,
             ) && let Some(ret) = infer_module_call_return(
@@ -2335,6 +2341,7 @@ fn infer_call_return_from_info(
                 func_map,
                 imports,
                 class_map,
+                diagnostics,
                 module_cache.as_deref_mut(),
                 module_path,
             ) {
@@ -2851,6 +2858,7 @@ fn infer_defined_call_return(
         func_map,
         imports,
         class_map,
+        diagnostics,
         module_cache.as_deref_mut(),
         module_path,
     ) {
@@ -2935,6 +2943,7 @@ fn infer_defined_call_return(
             func_map,
             imports,
             class_map,
+            diagnostics,
             module_cache.as_deref_mut(),
             module_path,
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 mod infer;
 mod module_resolution;
 pub mod op_groups;
+mod torch_nn;
 use crate::infer::{
     ShapeOrExpr, Transpose, infer_broadcastable_poswise, infer_condition, infer_conv,
     infer_creation_size, infer_flatten, infer_index, infer_matmul_shapes, infer_noop,
@@ -22,9 +23,9 @@ use crate::infer::{
 };
 pub use crate::module_resolution::ModuleCache;
 use crate::module_resolution::{
-    ClassMap, ClassRef, FuncMap, FunctionInfo, attr_state_from_expr, class_ref_from_annotation,
-    class_ref_from_expr, collect_class_defs, collect_function_defs, is_parameter_constructor,
-    method_param_offset, with_class_info,
+    ClassMap, ClassRef, FuncMap, FunctionInfo, ResolvedModule, attr_state_from_expr,
+    class_ref_from_annotation, collect_class_defs, collect_function_defs, is_parameter_constructor,
+    method_param_offset, resolved_module_from_expr, with_class_info,
 };
 pub use crate::op_groups::AGGR_ALIASES;
 use crate::op_groups::{BroadcastOp, Imports, TORCH_DTYPES, TorchOp, collect_imports};
@@ -106,7 +107,7 @@ fn range_span(range: &Range, _pos: &Position) -> u32 {
 struct VarState {
     annotated: Option<Shape>,
     inferred: Option<Shape>,
-    class_ref: Option<ClassRef>,
+    resolved_module: Option<ResolvedModule>,
 }
 
 fn state_shape(state: &VarState) -> Option<&Shape> {
@@ -486,7 +487,7 @@ fn analyze_function(
             VarState {
                 annotated: None,
                 inferred: None,
-                class_ref: Some(class_ref.clone()),
+                resolved_module: Some(ResolvedModule::User(class_ref.clone())),
             },
         );
     }
@@ -685,7 +686,7 @@ fn simulate_block(
                                 VarState {
                                     annotated: ann_shape.clone(),
                                     inferred: Some(renamed.clone()),
-                                    class_ref: None,
+                                    resolved_module: None,
                                 },
                             );
                             if record_hovers {
@@ -723,14 +724,14 @@ fn simulate_block(
                             VarState {
                                 annotated,
                                 inferred,
-                                class_ref: None,
+                                resolved_module: None,
                             },
                         );
                         if record_hovers {
                             push_assignment_hover(hover_entries, &assign.target, source, shape);
                         }
                     } else if let Some(val) = &assign.value
-                        && let Some(class_ref) = class_ref_from_expr(
+                        && let Some(resolved_module) = resolved_module_from_expr(
                             val,
                             vars,
                             source,
@@ -746,7 +747,7 @@ fn simulate_block(
                             VarState {
                                 annotated: ann_shape.clone(),
                                 inferred: None,
-                                class_ref: Some(class_ref.into_owned()),
+                                resolved_module: Some(resolved_module.into_owned()),
                             },
                         );
                     }
@@ -793,7 +794,7 @@ fn simulate_block(
                                 VarState {
                                     annotated: None,
                                     inferred: Some(shape.clone()),
-                                    class_ref: None,
+                                    resolved_module: None,
                                 },
                             );
                             if record_hovers {
@@ -827,13 +828,13 @@ fn simulate_block(
                             VarState {
                                 annotated: None,
                                 inferred: Some(shape.clone()),
-                                class_ref: None,
+                                resolved_module: None,
                             },
                         );
                         if record_hovers {
                             push_assignment_hover(hover_entries, &assign.targets[0], source, shape);
                         }
-                    } else if let Some(class_ref) = class_ref_from_expr(
+                    } else if let Some(resolved_module) = resolved_module_from_expr(
                         &assign.value,
                         vars,
                         source,
@@ -848,7 +849,7 @@ fn simulate_block(
                             VarState {
                                 annotated: None,
                                 inferred: None,
-                                class_ref: Some(class_ref.into_owned()),
+                                resolved_module: Some(resolved_module.into_owned()),
                             },
                         );
                     }
@@ -1245,7 +1246,7 @@ pub(crate) fn infer_expr_shape(
                     module_path,
                 );
             }
-            if let Some(class_ref) = class_ref_from_expr(
+            if let Some(resolved_module) = resolved_module_from_expr(
                 call.func.as_ref(),
                 vars,
                 source,
@@ -1254,9 +1255,10 @@ pub(crate) fn infer_expr_shape(
                 class_map,
                 module_cache.as_deref_mut(),
                 module_path,
-            ) && let Some(ret) = infer_class_call_return(
+            ) && let Some(ret) = infer_module_call_return(
                 call,
-                class_ref.as_ref(),
+                resolved_module.as_ref(),
+                ModuleCallable::Forward,
                 vars,
                 func_map,
                 imports,
@@ -1356,7 +1358,7 @@ pub(crate) fn infer_expr_shape(
             // methods are functions with attributes
             if let Expr::Attribute(attr) = call.func.as_ref() {
                 let attr_name: &str = attr.attr.as_ref();
-                if let Some(class_ref) = class_ref_from_expr(
+                if let Some(resolved_module) = resolved_module_from_expr(
                     attr.value.as_ref(),
                     vars,
                     source,
@@ -1365,10 +1367,10 @@ pub(crate) fn infer_expr_shape(
                     class_map,
                     module_cache.as_deref_mut(),
                     module_path,
-                ) && let Some(ret) = infer_class_method_call_return(
+                ) && let Some(ret) = infer_module_call_return(
                     call,
-                    class_ref.as_ref(),
-                    &attr.attr,
+                    resolved_module.as_ref(),
+                    ModuleCallable::Method(&attr.attr),
                     vars,
                     func_map,
                     imports,
@@ -2214,10 +2216,10 @@ fn infer_call_return_from_info(
                     VarState {
                         annotated: None,
                         inferred: Some(shape),
-                        class_ref: None,
+                        resolved_module: None,
                     },
                 );
-            } else if let Some(class_ref) = class_ref_from_expr(
+            } else if let Some(resolved_module) = resolved_module_from_expr(
                 arg_expr,
                 vars,
                 source,
@@ -2232,7 +2234,7 @@ fn infer_call_return_from_info(
                     VarState {
                         annotated: None,
                         inferred: None,
-                        class_ref: Some(class_ref.into_owned()),
+                        resolved_module: Some(resolved_module.into_owned()),
                     },
                 );
             }
@@ -2253,7 +2255,7 @@ fn infer_call_return_from_info(
                 VarState {
                     annotated: None,
                     inferred: None,
-                    class_ref: Some(self_class_ref.clone()),
+                    resolved_module: Some(ResolvedModule::User(self_class_ref.clone())),
                 },
             );
         }
@@ -2328,15 +2330,15 @@ fn infer_call_return_from_info(
 }
 
 #[derive(Clone, Copy)]
-enum ClassCallable<'a> {
+enum ModuleCallable<'a> {
     Forward,
     Method(&'a Identifier),
 }
 
-fn infer_class_member_call_return(
+fn infer_user_class_member_call_return(
     call: &ExprCall<TextRange>,
     class_ref: &ClassRef,
-    callable: ClassCallable<'_>,
+    callable: ModuleCallable<'_>,
     vars: &HashMap<Identifier, VarState>,
     func_map: &FuncMap,
     imports: &Imports,
@@ -2350,8 +2352,8 @@ fn infer_class_member_call_return(
     module_path: Option<&Path>,
 ) -> Option<ReturnValue> {
     let callee_name = match callable {
-        ClassCallable::Forward => class_ref.name.clone(),
-        ClassCallable::Method(method_name) => {
+        ModuleCallable::Forward => class_ref.name.clone(),
+        ModuleCallable::Method(method_name) => {
             Identifier::from(format!("{}::{}", class_ref.name, method_name))
         }
     };
@@ -2371,7 +2373,7 @@ fn infer_class_member_call_return(
          callee_path,
          module_cache| {
             let callee_info = match callable {
-                ClassCallable::Forward => {
+                ModuleCallable::Forward => {
                     if !class_info.is_torch_module {
                         return None;
                     }
@@ -2380,7 +2382,7 @@ fn infer_class_member_call_return(
                         .as_ref()
                         .and_then(|name| class_info.methods.get(name))?
                 }
-                ClassCallable::Method(method_name) => class_info.methods.get(method_name)?,
+                ModuleCallable::Method(method_name) => class_info.methods.get(method_name)?,
             };
             let param_offset = method_param_offset(&callee_info.args);
             infer_call_return_from_info(
@@ -2411,9 +2413,9 @@ fn infer_class_member_call_return(
     .flatten()
 }
 
-fn infer_class_call_return(
-    call: &ExprCall<TextRange>,
-    class_ref: &ClassRef,
+pub(crate) fn infer_resolved_module_shape(
+    resolved_module: &ResolvedModule,
+    base_shape: Shape,
     vars: &HashMap<Identifier, VarState>,
     func_map: &FuncMap,
     imports: &Imports,
@@ -2421,33 +2423,189 @@ fn infer_class_call_return(
     call_stack: &mut Vec<Identifier>,
     diagnostics: &mut Vec<Diagnostic>,
     hover_entries: &mut Vec<(Range, HoverInfo)>,
-    record_hovers: bool,
     source: &str,
+    range: TextRange,
     module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ReturnValue> {
-    infer_class_member_call_return(
-        call,
-        class_ref,
-        ClassCallable::Forward,
-        vars,
-        func_map,
-        imports,
-        class_map,
-        call_stack,
-        diagnostics,
-        hover_entries,
-        record_hovers,
-        source,
-        module_cache,
-        module_path,
-    )
+) -> Option<Shape> {
+    match resolved_module {
+        ResolvedModule::User(class_ref) => infer_user_class_shape_from_base(
+            class_ref,
+            base_shape,
+            vars,
+            func_map,
+            imports,
+            class_map,
+            call_stack,
+            diagnostics,
+            hover_entries,
+            source,
+            range,
+            module_cache,
+            module_path,
+        ),
+        ResolvedModule::Builtin(module) => module.infer_builtin_module(
+            base_shape,
+            vars,
+            func_map,
+            imports,
+            class_map,
+            call_stack,
+            diagnostics,
+            hover_entries,
+            source,
+            range,
+            module_cache,
+            module_path,
+        ),
+    }
 }
 
-fn infer_class_method_call_return(
-    call: &ExprCall<TextRange>,
+fn infer_user_class_shape_from_base(
     class_ref: &ClassRef,
-    method_name: &Identifier,
+    base_shape: Shape,
+    _vars: &HashMap<Identifier, VarState>,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    call_stack: &mut Vec<Identifier>,
+    diagnostics: &mut Vec<Diagnostic>,
+    _hover_entries: &mut Vec<(Range, HoverInfo)>,
+    source: &str,
+    range: TextRange,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<Shape> {
+    let callee_name = class_ref.name.clone();
+    if call_stack.iter().any(|id| id == &callee_name) {
+        return None;
+    }
+    with_class_info(
+        class_ref,
+        source,
+        func_map,
+        imports,
+        class_map,
+        &mut module_cache,
+        module_path,
+        |class_info,
+         callee_source,
+         callee_func_map,
+         callee_imports,
+         callee_class_map,
+         callee_path,
+         module_cache| {
+            if !class_info.is_torch_module {
+                return None;
+            }
+            let callee_info = class_info
+                .forward_name
+                .as_ref()
+                .and_then(|name| class_info.methods.get(name))?;
+            let param_offset = method_param_offset(&callee_info.args);
+            let input_param = callee_info.args.args.get(param_offset)?;
+            if callee_info.args.args.len() > param_offset + 1 {
+                return None;
+            }
+
+            let mut bindings = AnnotationBindings::default();
+            if let Some(ann) = input_param
+                .def
+                .annotation
+                .as_deref()
+                .and_then(parse_shape_annotation)
+            {
+                if let Some(local_bindings) = annotation_bindings(&ann.dims, &base_shape.dims) {
+                    bindings.merge_from(local_bindings);
+                } else {
+                    diagnostics.push(Diagnostic {
+                        range: text_range_to_lsp(range, source),
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        code: None,
+                        code_description: None,
+                        source: Some("shapels".into()),
+                        message: format!(
+                            "Shape mismatch: annotation {} vs inferred {}",
+                            ann.render(),
+                            base_shape.render()
+                        ),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    });
+                }
+            }
+
+            let mut arg_shapes = HashMap::new();
+            arg_shapes.insert(
+                input_param.def.arg.clone(),
+                VarState {
+                    annotated: None,
+                    inferred: Some(base_shape.clone()),
+                    resolved_module: None,
+                },
+            );
+            if param_offset > 0 {
+                arg_shapes.insert(
+                    Identifier::from("self"),
+                    VarState {
+                        annotated: None,
+                        inferred: None,
+                        resolved_module: Some(ResolvedModule::User(class_ref.clone())),
+                    },
+                );
+            }
+
+            if let Some(ret_ann) = callee_info.returns.as_deref() {
+                let annotated_return = if let Some(ret_shape) = parse_shape_annotation(ret_ann) {
+                    Some(ReturnValue::from_shape(instantiate_optional_shape(
+                        Some(ret_shape),
+                        &bindings,
+                    )))
+                } else if let Some(tuple_shapes) =
+                    tuple_shapes_from_annotation(ret_ann, callee_imports, callee_class_map)
+                {
+                    Some(instantiate_annotation_return(
+                        ReturnValue::from_tuple(tuple_shapes),
+                        &bindings,
+                    ))
+                } else {
+                    let (shape_union, _) =
+                        shape_or_class_from_union(ret_ann, callee_imports, callee_class_map);
+                    shape_union.map(|shape| {
+                        ReturnValue::from_shape(instantiate_optional_shape(Some(shape), &bindings))
+                    })
+                };
+                if let Some(ret) = annotated_return {
+                    return ret.first().cloned();
+                }
+            }
+
+            call_stack.push(callee_name.clone());
+            let (_, _, ret_value) = simulate_function(
+                callee_info.args.as_ref(),
+                &callee_info.body,
+                callee_source,
+                callee_func_map,
+                callee_imports,
+                callee_class_map,
+                call_stack,
+                arg_shapes,
+                false,
+                module_cache.as_deref_mut(),
+                callee_path,
+            );
+            call_stack.pop();
+            ret_value.first().cloned()
+        },
+    )
+    .flatten()
+}
+
+fn infer_module_call_return(
+    call: &ExprCall<TextRange>,
+    resolved_module: &ResolvedModule,
+    callable: ModuleCallable<'_>,
     vars: &HashMap<Identifier, VarState>,
     func_map: &FuncMap,
     imports: &Imports,
@@ -2457,25 +2615,106 @@ fn infer_class_method_call_return(
     hover_entries: &mut Vec<(Range, HoverInfo)>,
     record_hovers: bool,
     source: &str,
-    module_cache: Option<&mut ModuleCache>,
+    mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<ReturnValue> {
-    infer_class_member_call_return(
-        call,
-        class_ref,
-        ClassCallable::Method(method_name),
-        vars,
-        func_map,
-        imports,
-        class_map,
-        call_stack,
-        diagnostics,
-        hover_entries,
-        record_hovers,
-        source,
-        module_cache,
-        module_path,
-    )
+    match resolved_module {
+        ResolvedModule::User(class_ref) => infer_user_class_member_call_return(
+            call,
+            class_ref,
+            callable,
+            vars,
+            func_map,
+            imports,
+            class_map,
+            call_stack,
+            diagnostics,
+            hover_entries,
+            record_hovers,
+            source,
+            module_cache,
+            module_path,
+        ),
+        ResolvedModule::Builtin(module) => {
+            match callable {
+                ModuleCallable::Forward => {
+                    let base_expr = call.args.first()?;
+                    let base_shape =
+                        lookup_shape(base_expr, vars, hover_entries, record_hovers, source)
+                            .or_else(|| {
+                                infer_expr_shape(
+                                    base_expr,
+                                    vars,
+                                    func_map,
+                                    imports,
+                                    class_map,
+                                    call_stack,
+                                    diagnostics,
+                                    hover_entries,
+                                    false,
+                                    source,
+                                    module_cache.as_deref_mut(),
+                                    module_path,
+                                )
+                            })?;
+                    infer_resolved_module_shape(
+                        resolved_module,
+                        base_shape,
+                        vars,
+                        func_map,
+                        imports,
+                        class_map,
+                        call_stack,
+                        diagnostics,
+                        hover_entries,
+                        source,
+                        call.range,
+                        module_cache.as_deref_mut(),
+                        module_path,
+                    )
+                    .map(|shape| ReturnValue::from_shape(Some(shape)))
+                }
+                ModuleCallable::Method(method_name) if method_name.as_str() == "forward" => {
+                    let base_expr = call.args.first()?;
+                    let base_shape =
+                        lookup_shape(base_expr, vars, hover_entries, record_hovers, source)
+                            .or_else(|| {
+                                infer_expr_shape(
+                                    base_expr,
+                                    vars,
+                                    func_map,
+                                    imports,
+                                    class_map,
+                                    call_stack,
+                                    diagnostics,
+                                    hover_entries,
+                                    false,
+                                    source,
+                                    module_cache.as_deref_mut(),
+                                    module_path,
+                                )
+                            })?;
+                    module
+                        .infer_builtin_module(
+                            base_shape,
+                            vars,
+                            func_map,
+                            imports,
+                            class_map,
+                            call_stack,
+                            diagnostics,
+                            hover_entries,
+                            source,
+                            call.range,
+                            module_cache.as_deref_mut(),
+                            module_path,
+                        )
+                        .map(|shape| ReturnValue::from_shape(Some(shape)))
+                }
+                ModuleCallable::Method(_) => None,
+            }
+        }
+    }
 }
 
 fn infer_defined_call_return(
@@ -2495,7 +2734,7 @@ fn infer_defined_call_return(
     if report_unbound_self_diagnostic(call.func.as_ref(), vars, diagnostics, source) {
         return None;
     }
-    if let Some(class_ref) = class_ref_from_expr(
+    if let Some(resolved_module) = resolved_module_from_expr(
         call.func.as_ref(),
         vars,
         source,
@@ -2505,9 +2744,10 @@ fn infer_defined_call_return(
         module_cache.as_deref_mut(),
         module_path,
     ) {
-        return infer_class_call_return(
+        return infer_module_call_return(
             call,
-            class_ref.as_ref(),
+            resolved_module.as_ref(),
+            ModuleCallable::Forward,
             vars,
             func_map,
             imports,
@@ -2578,7 +2818,7 @@ fn infer_defined_call_return(
         }
     }
     if let Expr::Attribute(attr) = call.func.as_ref()
-        && let Some(class_ref) = class_ref_from_expr(
+        && let Some(resolved_module) = resolved_module_from_expr(
             attr.value.as_ref(),
             vars,
             source,
@@ -2589,10 +2829,10 @@ fn infer_defined_call_return(
             module_path,
         )
     {
-        return infer_class_method_call_return(
+        return infer_module_call_return(
             call,
-            class_ref.as_ref(),
-            &attr.attr,
+            resolved_module.as_ref(),
+            ModuleCallable::Method(&attr.attr),
             vars,
             func_map,
             imports,
@@ -2776,7 +3016,7 @@ fn assignment_shape_checks(
                 VarState {
                     annotated: None,
                     inferred: Some(new_shape.clone()),
-                    class_ref: None,
+                    resolved_module: None,
                 },
             );
             if record_hovers {
@@ -2811,7 +3051,7 @@ fn assignment_shape_checks(
             VarState {
                 annotated: None,
                 inferred: Some(new_shape.clone()),
-                class_ref: None,
+                resolved_module: None,
             },
         );
         if record_hovers {
@@ -2921,19 +3161,21 @@ fn seed_args_from_annotations(
         let state = VarState {
             annotated: ann_shape.or(union_shape),
             inferred: provided_state.and_then(|s| s.inferred.clone()),
-            class_ref: provided_state
-                .and_then(|s| s.class_ref.clone())
+            resolved_module: provided_state
+                .and_then(|s| s.resolved_module.clone())
                 .or_else(|| {
                     arg.def
                         .annotation
                         .as_ref()
                         .and_then(|ann| class_ref_from_annotation(ann.as_ref(), imports, class_map))
+                        .map(ResolvedModule::User)
                 })
-                .or(union_class),
+                .or_else(|| union_class.map(ResolvedModule::User)),
         };
         let hover_shape = state_shape(&state).cloned();
 
-        if state.annotated.is_some() || state.inferred.is_some() || state.class_ref.is_some() {
+        if state.annotated.is_some() || state.inferred.is_some() || state.resolved_module.is_some()
+        {
             vars.insert(arg.def.arg.clone(), state);
             if record_hovers {
                 hover_entries.push((range, HoverInfo { shape: hover_shape }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ use crate::infer::{
 pub use crate::module_resolution::ModuleCache;
 use crate::module_resolution::{
     ClassMap, ClassRef, FuncMap, FunctionInfo, ResolvedModule, attr_state_from_expr,
-    class_ref_from_annotation, collect_class_defs, collect_function_defs, is_parameter_constructor,
-    method_param_offset, resolved_module_from_expr, self_attr_module_from_self, with_class_info,
+    class_ref_from_annotation, collect_class_defs, collect_function_defs, method_param_offset,
+    resolved_module_from_expr, self_attr_module_from_self, with_class_info,
 };
 pub use crate::op_groups::AGGR_ALIASES;
 use crate::op_groups::{BroadcastOp, Imports, TORCH_DTYPES, TorchOp, collect_imports};
@@ -1231,7 +1231,7 @@ pub(crate) fn infer_expr_shape(
             if report_unbound_self_diagnostic(call.func.as_ref(), vars, diagnostics, source) {
                 return None;
             }
-            if is_parameter_constructor(call.func.as_ref(), imports)
+            if imports.is_torch_nn_storage_constructor(call.func.as_ref())
                 && let Some(base) = call.args.first()
             {
                 return infer_expr_shape(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+mod expr_tokens;
 mod infer;
 mod module_resolution;
 pub mod op_groups;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::module_resolution::ModuleCache;
 use crate::module_resolution::{
     ClassMap, ClassRef, FuncMap, FunctionInfo, ResolvedModule, attr_state_from_expr,
     class_ref_from_annotation, collect_class_defs, collect_function_defs, is_parameter_constructor,
-    method_param_offset, resolved_module_from_expr, with_class_info,
+    method_param_offset, resolved_module_from_expr, self_attr_module_from_self, with_class_info,
 };
 pub use crate::op_groups::AGGR_ALIASES;
 use crate::op_groups::{BroadcastOp, Imports, TORCH_DTYPES, TorchOp, collect_imports};
@@ -1246,33 +1246,6 @@ pub(crate) fn infer_expr_shape(
                     module_path,
                 );
             }
-            if let Some(resolved_module) = resolved_module_from_expr(
-                call.func.as_ref(),
-                vars,
-                source,
-                func_map,
-                imports,
-                class_map,
-                module_cache.as_deref_mut(),
-                module_path,
-            ) && let Some(ret) = infer_module_call_return(
-                call,
-                resolved_module.as_ref(),
-                ModuleCallable::Forward,
-                vars,
-                func_map,
-                imports,
-                class_map,
-                call_stack,
-                diagnostics,
-                hover_entries,
-                record_hovers,
-                source,
-                module_cache.as_deref_mut(),
-                module_path,
-            ) {
-                return ret.first().cloned();
-            }
             if let Expr::Name(func_name) = call.func.as_ref() {
                 let torchop_shape = torch_op_to_shape(
                     vars,
@@ -1294,6 +1267,33 @@ pub(crate) fn infer_expr_shape(
                 );
                 if torchop_shape.is_some() {
                     return torchop_shape;
+                }
+                if let Some(resolved_module) = resolved_module_from_expr(
+                    call.func.as_ref(),
+                    vars,
+                    source,
+                    func_map,
+                    imports,
+                    class_map,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) && let Some(ret) = infer_module_call_return(
+                    call,
+                    resolved_module.as_ref(),
+                    ModuleCallable::Forward,
+                    vars,
+                    func_map,
+                    imports,
+                    class_map,
+                    call_stack,
+                    diagnostics,
+                    hover_entries,
+                    record_hovers,
+                    source,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) {
+                    return ret.first().cloned();
                 }
 
                 if let Some((module_name, original)) = imports.from_imports.get(&func_name.id)
@@ -1358,8 +1358,61 @@ pub(crate) fn infer_expr_shape(
             // methods are functions with attributes
             if let Expr::Attribute(attr) = call.func.as_ref() {
                 let attr_name: &str = attr.attr.as_ref();
+                if matches!(attr.value.as_ref(), Expr::Name(name) if name.id.as_str() == "self")
+                    && let Some(resolved_module) = self_attr_module_from_self(
+                        &attr.attr,
+                        vars,
+                        source,
+                        func_map,
+                        imports,
+                        class_map,
+                        module_cache.as_deref_mut(),
+                        module_path,
+                    )
+                    && let Some(ret) = infer_module_call_return(
+                        call,
+                        resolved_module.as_ref(),
+                        ModuleCallable::Forward,
+                        vars,
+                        func_map,
+                        imports,
+                        class_map,
+                        call_stack,
+                        diagnostics,
+                        hover_entries,
+                        record_hovers,
+                        source,
+                        module_cache.as_deref_mut(),
+                        module_path,
+                    )
+                {
+                    return ret.first().cloned();
+                }
+                // two cases: torch.ATTR_NAME(torch.Tensor, ...) or torch.Tensor.ATTR_NAME(...)
+                let op_kind = function_or_method(&attr.value, imports);
+                let aliased_shape = torch_op_to_shape(
+                    vars,
+                    func_map,
+                    imports,
+                    class_map,
+                    call_stack,
+                    diagnostics,
+                    hover_entries,
+                    record_hovers,
+                    source,
+                    &mut module_cache,
+                    module_path,
+                    call,
+                    attr_name,
+                    TorchOp::from_attr(attr_name),
+                    op_kind,
+                    Some(attr),
+                );
+                if aliased_shape.is_some() {
+                    return aliased_shape;
+                }
                 if let Some(resolved_module) = resolved_module_from_expr(
-                    attr.value.as_ref(),
+                    call.func.as_ref(),
                     vars,
                     source,
                     func_map,
@@ -1370,7 +1423,7 @@ pub(crate) fn infer_expr_shape(
                 ) && let Some(ret) = infer_module_call_return(
                     call,
                     resolved_module.as_ref(),
-                    ModuleCallable::Method(&attr.attr),
+                    ModuleCallable::Forward,
                     vars,
                     func_map,
                     imports,
@@ -1418,9 +1471,19 @@ pub(crate) fn infer_expr_shape(
                 {
                     return ret.first().cloned();
                 }
-                // two cases: torch.ATTR_NAME(torch.Tensor, ...) or torch.Tensor.ATTR_NAME(...)
-                let op_kind = function_or_method(&attr.value, imports);
-                let aliased_shape = torch_op_to_shape(
+                if let Some(resolved_module) = resolved_module_from_expr(
+                    attr.value.as_ref(),
+                    vars,
+                    source,
+                    func_map,
+                    imports,
+                    class_map,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) && let Some(ret) = infer_module_call_return(
+                    call,
+                    resolved_module.as_ref(),
+                    ModuleCallable::Method(&attr.attr),
                     vars,
                     func_map,
                     imports,
@@ -1430,17 +1493,39 @@ pub(crate) fn infer_expr_shape(
                     hover_entries,
                     record_hovers,
                     source,
-                    &mut module_cache,
+                    module_cache.as_deref_mut(),
                     module_path,
-                    call,
-                    attr_name,
-                    TorchOp::from_attr(attr_name),
-                    op_kind,
-                    Some(attr),
-                );
-                if aliased_shape.is_some() {
-                    return aliased_shape;
+                ) {
+                    return ret.first().cloned();
                 }
+                return None;
+            }
+            if let Some(resolved_module) = resolved_module_from_expr(
+                call.func.as_ref(),
+                vars,
+                source,
+                func_map,
+                imports,
+                class_map,
+                module_cache.as_deref_mut(),
+                module_path,
+            ) && let Some(ret) = infer_module_call_return(
+                call,
+                resolved_module.as_ref(),
+                ModuleCallable::Forward,
+                vars,
+                func_map,
+                imports,
+                class_map,
+                call_stack,
+                diagnostics,
+                hover_entries,
+                record_hovers,
+                source,
+                module_cache.as_deref_mut(),
+                module_path,
+            ) {
+                return ret.first().cloned();
             }
             None
         }
@@ -2135,6 +2220,29 @@ fn instantiate_annotation_return(ret: ReturnValue, bindings: &AnnotationBindings
     }
 }
 
+fn annotated_return_from_expr(
+    ret_ann: &Expr,
+    imports: &Imports,
+    class_map: &ClassMap,
+    bindings: &AnnotationBindings,
+) -> Option<ReturnValue> {
+    if let Some(ret_shape) = parse_shape_annotation(ret_ann) {
+        Some(ReturnValue::from_shape(instantiate_optional_shape(
+            Some(ret_shape),
+            bindings,
+        )))
+    } else if let Some(tuple_shapes) = tuple_shapes_from_annotation(ret_ann, imports, class_map) {
+        Some(instantiate_annotation_return(
+            ReturnValue::from_tuple(tuple_shapes),
+            bindings,
+        ))
+    } else {
+        let (shape_union, _) = shape_or_class_from_union(ret_ann, imports, class_map);
+        shape_union
+            .map(|shape| ReturnValue::from_shape(instantiate_optional_shape(Some(shape), bindings)))
+    }
+}
+
 fn is_concrete_dim(dim: &str) -> bool {
     dim.parse::<i64>().is_ok()
 }
@@ -2260,50 +2368,33 @@ fn infer_call_return_from_info(
             );
         }
     }
-    if let Some(ret_ann) = callee_info.returns.as_deref() {
-        let annotated_return = if let Some(ret_shape) = parse_shape_annotation(ret_ann) {
-            Some(ReturnValue::from_shape(instantiate_optional_shape(
-                Some(ret_shape),
-                &bindings,
-            )))
-        } else if let Some(tuple_shapes) = tuple_shapes_from_annotation(ret_ann, imports, class_map)
-        {
-            Some(instantiate_annotation_return(
-                ReturnValue::from_tuple(tuple_shapes),
-                &bindings,
-            ))
-        } else {
-            let (shape_union, _) = shape_or_class_from_union(ret_ann, imports, class_map);
-            shape_union.map(|shape| {
-                ReturnValue::from_shape(instantiate_optional_shape(Some(shape), &bindings))
-            })
-        };
-        if let Some(ret) = annotated_return {
-            if emit_body_diagnostics || record_hovers {
-                call_stack.push(callee_name.clone());
-                let (mut diag, mut hovers, _) = simulate_function(
-                    callee_info.args.as_ref(),
-                    &callee_info.body,
-                    callee_source,
-                    callee_func_map,
-                    callee_imports,
-                    callee_class_map,
-                    call_stack,
-                    arg_shapes,
-                    record_hovers,
-                    module_cache.as_deref_mut(),
-                    module_path,
-                );
-                if emit_body_diagnostics {
-                    diagnostics.append(&mut diag);
-                }
-                if record_hovers {
-                    hover_entries.append(&mut hovers);
-                }
-                call_stack.pop();
+    if let Some(ret_ann) = callee_info.returns.as_deref()
+        && let Some(ret) = annotated_return_from_expr(ret_ann, imports, class_map, &bindings)
+    {
+        if emit_body_diagnostics || record_hovers {
+            call_stack.push(callee_name.clone());
+            let (mut diag, mut hovers, _) = simulate_function(
+                callee_info.args.as_ref(),
+                &callee_info.body,
+                callee_source,
+                callee_func_map,
+                callee_imports,
+                callee_class_map,
+                call_stack,
+                arg_shapes,
+                record_hovers,
+                module_cache.as_deref_mut(),
+                module_path,
+            );
+            if emit_body_diagnostics {
+                diagnostics.append(&mut diag);
             }
-            return Some(ret);
+            if record_hovers {
+                hover_entries.append(&mut hovers);
+            }
+            call_stack.pop();
         }
+        return Some(ret);
     }
     call_stack.push(callee_name.clone());
     let (mut diag, mut hovers, ret_value) = simulate_function(
@@ -2461,6 +2552,86 @@ pub(crate) fn infer_resolved_module_shape(
     }
 }
 
+fn infer_call_base_shape(
+    call: &ExprCall<TextRange>,
+    vars: &HashMap<Identifier, VarState>,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    call_stack: &mut Vec<Identifier>,
+    diagnostics: &mut Vec<Diagnostic>,
+    hover_entries: &mut Vec<(Range, HoverInfo)>,
+    record_hovers: bool,
+    source: &str,
+    module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<Shape> {
+    let base_expr = call.args.first()?;
+    lookup_shape(base_expr, vars, hover_entries, record_hovers, source).or_else(|| {
+        infer_expr_shape(
+            base_expr,
+            vars,
+            func_map,
+            imports,
+            class_map,
+            call_stack,
+            diagnostics,
+            hover_entries,
+            false,
+            source,
+            module_cache,
+            module_path,
+        )
+    })
+}
+
+fn infer_builtin_module_call_return(
+    module: &crate::torch_nn::TorchNNModule,
+    call: &ExprCall<TextRange>,
+    vars: &HashMap<Identifier, VarState>,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    call_stack: &mut Vec<Identifier>,
+    diagnostics: &mut Vec<Diagnostic>,
+    hover_entries: &mut Vec<(Range, HoverInfo)>,
+    record_hovers: bool,
+    source: &str,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ReturnValue> {
+    let base_shape = infer_call_base_shape(
+        call,
+        vars,
+        func_map,
+        imports,
+        class_map,
+        call_stack,
+        diagnostics,
+        hover_entries,
+        record_hovers,
+        source,
+        module_cache.as_deref_mut(),
+        module_path,
+    )?;
+    module
+        .infer_builtin_module(
+            base_shape,
+            vars,
+            func_map,
+            imports,
+            class_map,
+            call_stack,
+            diagnostics,
+            hover_entries,
+            source,
+            call.range,
+            module_cache,
+            module_path,
+        )
+        .map(|shape| ReturnValue::from_shape(Some(shape)))
+}
+
 fn infer_user_class_shape_from_base(
     class_ref: &ClassRef,
     base_shape: Shape,
@@ -2556,29 +2727,11 @@ fn infer_user_class_shape_from_base(
                 );
             }
 
-            if let Some(ret_ann) = callee_info.returns.as_deref() {
-                let annotated_return = if let Some(ret_shape) = parse_shape_annotation(ret_ann) {
-                    Some(ReturnValue::from_shape(instantiate_optional_shape(
-                        Some(ret_shape),
-                        &bindings,
-                    )))
-                } else if let Some(tuple_shapes) =
-                    tuple_shapes_from_annotation(ret_ann, callee_imports, callee_class_map)
-                {
-                    Some(instantiate_annotation_return(
-                        ReturnValue::from_tuple(tuple_shapes),
-                        &bindings,
-                    ))
-                } else {
-                    let (shape_union, _) =
-                        shape_or_class_from_union(ret_ann, callee_imports, callee_class_map);
-                    shape_union.map(|shape| {
-                        ReturnValue::from_shape(instantiate_optional_shape(Some(shape), &bindings))
-                    })
-                };
-                if let Some(ret) = annotated_return {
-                    return ret.first().cloned();
-                }
+            if let Some(ret_ann) = callee_info.returns.as_deref()
+                && let Some(ret) =
+                    annotated_return_from_expr(ret_ann, callee_imports, callee_class_map, &bindings)
+            {
+                return ret.first().cloned();
             }
 
             call_stack.push(callee_name.clone());
@@ -2615,7 +2768,7 @@ fn infer_module_call_return(
     hover_entries: &mut Vec<(Range, HoverInfo)>,
     record_hovers: bool,
     source: &str,
-    mut module_cache: Option<&mut ModuleCache>,
+    module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<ReturnValue> {
     match resolved_module {
@@ -2635,85 +2788,41 @@ fn infer_module_call_return(
             module_cache,
             module_path,
         ),
-        ResolvedModule::Builtin(module) => {
-            match callable {
-                ModuleCallable::Forward => {
-                    let base_expr = call.args.first()?;
-                    let base_shape =
-                        lookup_shape(base_expr, vars, hover_entries, record_hovers, source)
-                            .or_else(|| {
-                                infer_expr_shape(
-                                    base_expr,
-                                    vars,
-                                    func_map,
-                                    imports,
-                                    class_map,
-                                    call_stack,
-                                    diagnostics,
-                                    hover_entries,
-                                    false,
-                                    source,
-                                    module_cache.as_deref_mut(),
-                                    module_path,
-                                )
-                            })?;
-                    infer_resolved_module_shape(
-                        resolved_module,
-                        base_shape,
-                        vars,
-                        func_map,
-                        imports,
-                        class_map,
-                        call_stack,
-                        diagnostics,
-                        hover_entries,
-                        source,
-                        call.range,
-                        module_cache.as_deref_mut(),
-                        module_path,
-                    )
-                    .map(|shape| ReturnValue::from_shape(Some(shape)))
-                }
-                ModuleCallable::Method(method_name) if method_name.as_str() == "forward" => {
-                    let base_expr = call.args.first()?;
-                    let base_shape =
-                        lookup_shape(base_expr, vars, hover_entries, record_hovers, source)
-                            .or_else(|| {
-                                infer_expr_shape(
-                                    base_expr,
-                                    vars,
-                                    func_map,
-                                    imports,
-                                    class_map,
-                                    call_stack,
-                                    diagnostics,
-                                    hover_entries,
-                                    false,
-                                    source,
-                                    module_cache.as_deref_mut(),
-                                    module_path,
-                                )
-                            })?;
-                    module
-                        .infer_builtin_module(
-                            base_shape,
-                            vars,
-                            func_map,
-                            imports,
-                            class_map,
-                            call_stack,
-                            diagnostics,
-                            hover_entries,
-                            source,
-                            call.range,
-                            module_cache.as_deref_mut(),
-                            module_path,
-                        )
-                        .map(|shape| ReturnValue::from_shape(Some(shape)))
-                }
-                ModuleCallable::Method(_) => None,
+        ResolvedModule::Builtin(module) => match callable {
+            ModuleCallable::Forward => infer_builtin_module_call_return(
+                module,
+                call,
+                vars,
+                func_map,
+                imports,
+                class_map,
+                call_stack,
+                diagnostics,
+                hover_entries,
+                record_hovers,
+                source,
+                module_cache,
+                module_path,
+            ),
+            ModuleCallable::Method(method_name) if method_name.as_str() == "forward" => {
+                infer_builtin_module_call_return(
+                    module,
+                    call,
+                    vars,
+                    func_map,
+                    imports,
+                    class_map,
+                    call_stack,
+                    diagnostics,
+                    hover_entries,
+                    record_hovers,
+                    source,
+                    module_cache,
+                    module_path,
+                )
             }
-        }
+            ModuleCallable::Method(_) => None,
+        },
     }
 }
 

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -261,23 +261,7 @@ fn is_torch_nn_module_base(expr: &Expr, imports: &Imports) -> bool {
     let Expr::Attribute(attr) = expr else {
         return false;
     };
-    if attr.attr.as_str() != "Module" {
-        return false;
-    }
-    match attr.value.as_ref() {
-        Expr::Attribute(nn_attr) if nn_attr.attr.as_str() == "nn" => {
-            if let Expr::Name(torch_name) = nn_attr.value.as_ref() {
-                return imports.torch_aliases.contains(&torch_name.id);
-            }
-            false
-        }
-        Expr::Name(nn_name) => imports
-            .module_aliases
-            .get(&nn_name.id)
-            .map(|module| module == "torch.nn")
-            .unwrap_or(false),
-        _ => false,
-    }
+    attr.attr.as_str() == "Module" && is_torch_nn_namespace(attr.value.as_ref(), imports)
 }
 
 /// Collect class definitions and mark which ones inherit from `torch.nn.Module`.
@@ -530,6 +514,18 @@ fn is_torch_namespace(expr: &Expr, imports: &Imports) -> bool {
     matches!(expr, Expr::Name(name) if imports.torch_aliases.contains(&name.id))
 }
 
+pub(crate) fn is_torch_nn_namespace(expr: &Expr, imports: &Imports) -> bool {
+    match expr {
+        Expr::Name(name) => imports.is_module_alias(&name.id, "torch.nn"),
+        Expr::Attribute(attr)
+            if attr.attr.as_str() == "nn" && is_torch_namespace(attr.value.as_ref(), imports) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
 pub(crate) fn imported_class_ref(
     module_name: &str,
     class_name: &Identifier,
@@ -552,24 +548,12 @@ pub(crate) fn imported_class_ref(
 pub(crate) fn is_parameter_constructor(func: &Expr, imports: &Imports) -> bool {
     match func {
         Expr::Name(name) => imports
-            .from_imports
-            .get(&name.id)
-            .map(|(module, original)| module == "torch.nn" && original.as_str() == "Parameter")
+            .imported_symbol_from(&name.id, "torch.nn")
+            .map(|original| original.as_str() == "Parameter")
             .unwrap_or(false),
-        Expr::Attribute(attr) if attr.attr.as_str() == "Parameter" => match attr.value.as_ref() {
-            Expr::Name(name) => imports
-                .module_aliases
-                .get(&name.id)
-                .map(|module| module == "torch.nn")
-                .unwrap_or(false),
-            Expr::Attribute(nn_attr)
-                if nn_attr.attr.as_str() == "nn"
-                    && is_torch_namespace(nn_attr.value.as_ref(), imports) =>
-            {
-                true
-            }
-            _ => false,
-        },
+        Expr::Attribute(attr) => {
+            attr.attr.as_str() == "Parameter" && is_torch_nn_namespace(attr.value.as_ref(), imports)
+        }
         _ => false,
     }
 }

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -10,6 +10,7 @@ use crate::infer::infer_creation_size;
 use crate::infer_expr_shape;
 use crate::normalize_return_annotations;
 use crate::op_groups::{Imports, TorchOp, collect_imports};
+use crate::torch_nn::{TorchNNModule, module_from_constructor_call};
 use rustpython_parser::Parse;
 use rustpython_parser::ast::{Arguments, Expr, ExprCall, Identifier, Stmt, Suite};
 use std::cell::RefCell;
@@ -45,6 +46,21 @@ pub(crate) struct ClassInfo {
 }
 
 pub(crate) type ClassMap = HashMap<Identifier, ClassInfo>;
+
+#[derive(Debug, Clone)]
+pub(crate) enum ResolvedModule {
+    User(ClassRef),
+    Builtin(TorchNNModule),
+}
+
+impl ResolvedModule {
+    pub(crate) fn as_user(&self) -> Option<&ClassRef> {
+        match self {
+            Self::User(class_ref) => Some(class_ref),
+            Self::Builtin(_) => None,
+        }
+    }
+}
 
 /// Parsed module data reused by cross-file inference.
 pub(crate) struct CachedModule {
@@ -342,23 +358,23 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
         .collect()
 }
 
-pub(crate) enum ResolvedClassRef<'a> {
-    Borrowed(&'a ClassRef),
-    Owned(ClassRef),
+pub(crate) enum ResolvedModuleRef<'a> {
+    Borrowed(&'a ResolvedModule),
+    Owned(ResolvedModule),
 }
 
-impl<'a> ResolvedClassRef<'a> {
-    pub(crate) fn as_ref(&self) -> &ClassRef {
+impl<'a> ResolvedModuleRef<'a> {
+    pub(crate) fn as_ref(&self) -> &ResolvedModule {
         match self {
-            Self::Borrowed(class_ref) => class_ref,
-            Self::Owned(class_ref) => class_ref,
+            Self::Borrowed(module) => module,
+            Self::Owned(module) => module,
         }
     }
 
-    pub(crate) fn into_owned(self) -> ClassRef {
+    pub(crate) fn into_owned(self) -> ResolvedModule {
         match self {
-            Self::Borrowed(class_ref) => class_ref.clone(),
-            Self::Owned(class_ref) => class_ref,
+            Self::Borrowed(module) => module.clone(),
+            Self::Owned(module) => module,
         }
     }
 }
@@ -443,8 +459,8 @@ pub(crate) fn class_ref_from_annotation(
     None
 }
 
-/// Resolve a class-valued expression from either a constructor call or a bound variable.
-pub(crate) fn class_ref_from_expr<'a>(
+/// Resolve a module-valued expression from either a constructor call or a bound variable.
+pub(crate) fn resolved_module_from_expr<'a>(
     expr: &Expr,
     vars: &'a HashMap<Identifier, VarState>,
     source: &str,
@@ -453,17 +469,17 @@ pub(crate) fn class_ref_from_expr<'a>(
     class_map: &ClassMap,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ResolvedClassRef<'a>> {
-    if let Some(class_ref) = class_ref_from_constructor_call(
+) -> Option<ResolvedModuleRef<'a>> {
+    if let Some(resolved_module) = module_from_constructor_call(
         expr,
         class_map,
         imports,
         module_cache.as_deref_mut(),
         module_path,
     ) {
-        return Some(ResolvedClassRef::Owned(class_ref));
+        return Some(ResolvedModuleRef::Owned(resolved_module));
     }
-    resolve_class_ref_expr(
+    resolve_module_expr(
         expr,
         vars,
         source,
@@ -493,15 +509,15 @@ fn shape_state(shape: crate::Shape) -> VarState {
     VarState {
         annotated: None,
         inferred: Some(shape),
-        class_ref: None,
+        resolved_module: None,
     }
 }
 
-fn class_state(class_ref: ClassRef) -> VarState {
+fn module_state(resolved_module: ResolvedModule) -> VarState {
     VarState {
         annotated: None,
         inferred: None,
-        class_ref: Some(class_ref),
+        resolved_module: Some(resolved_module),
     }
 }
 
@@ -509,7 +525,7 @@ fn is_torch_namespace(expr: &Expr, imports: &Imports) -> bool {
     matches!(expr, Expr::Name(name) if imports.torch_aliases.contains(&name.id))
 }
 
-fn imported_class_ref(
+pub(crate) fn imported_class_ref(
     module_name: &str,
     class_name: &Identifier,
     module_cache: Option<&mut ModuleCache>,
@@ -590,14 +606,14 @@ fn infer_tracked_state_from_expr(
     module_path: Option<&Path>,
     source: &str,
 ) -> Option<VarState> {
-    if let Some(class_ref) = class_ref_from_constructor_call(
+    if let Some(resolved_module) = module_from_constructor_call(
         expr,
         class_map,
         imports,
         module_cache.as_deref_mut(),
         module_path,
     ) {
-        return Some(class_state(class_ref));
+        return Some(module_state(resolved_module));
     }
 
     if let Expr::Name(name) = expr {
@@ -817,7 +833,7 @@ pub(crate) fn attr_state_from_expr(
     let Expr::Attribute(attr) = expr else {
         return None;
     };
-    let base_class_ref = resolve_class_ref_expr(
+    let base_module = resolve_module_expr(
         attr.value.as_ref(),
         vars,
         source,
@@ -828,7 +844,7 @@ pub(crate) fn attr_state_from_expr(
         module_path,
     )?;
     resolve_cached_self_attr_state(
-        base_class_ref.as_ref(),
+        base_module.as_ref().as_user()?,
         &attr.attr,
         source,
         func_map,
@@ -839,7 +855,7 @@ pub(crate) fn attr_state_from_expr(
     )
 }
 
-fn resolve_class_ref_expr<'a>(
+fn resolve_module_expr<'a>(
     expr: &Expr,
     vars: &'a HashMap<Identifier, VarState>,
     source: &str,
@@ -848,14 +864,14 @@ fn resolve_class_ref_expr<'a>(
     class_map: &ClassMap,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
-) -> Option<ResolvedClassRef<'a>> {
+) -> Option<ResolvedModuleRef<'a>> {
     match expr {
         Expr::Name(name) => vars
             .get(&name.id)
-            .and_then(|v| v.class_ref.as_ref())
-            .map(ResolvedClassRef::Borrowed),
+            .and_then(|v| v.resolved_module.as_ref())
+            .map(ResolvedModuleRef::Borrowed),
         Expr::Attribute(attr) => {
-            let base_class_ref = resolve_class_ref_expr(
+            let base_module = resolve_module_expr(
                 attr.value.as_ref(),
                 vars,
                 source,
@@ -866,7 +882,7 @@ fn resolve_class_ref_expr<'a>(
                 module_path,
             )?;
             resolve_cached_self_attr_state(
-                base_class_ref.as_ref(),
+                base_module.as_ref().as_user()?,
                 &attr.attr,
                 source,
                 func_map,
@@ -875,55 +891,11 @@ fn resolve_class_ref_expr<'a>(
                 &mut module_cache,
                 module_path,
             )
-            .and_then(|state| state.class_ref)
-            .map(ResolvedClassRef::Owned)
+            .and_then(|state| state.resolved_module)
+            .map(ResolvedModuleRef::Owned)
         }
         _ => None,
     }
-}
-
-/// Resolve constructor calls to user-defined classes, including imported classes.
-fn class_ref_from_constructor_call(
-    call_expr: &Expr,
-    class_map: &ClassMap,
-    imports: &Imports,
-    mut module_cache: Option<&mut ModuleCache>,
-    module_path: Option<&Path>,
-) -> Option<ClassRef> {
-    let Expr::Call(call) = call_expr else {
-        return None;
-    };
-    match call.func.as_ref() {
-        Expr::Name(name) => {
-            if class_map.contains_key(&name.id) {
-                return Some(ClassRef {
-                    name: name.id.clone(),
-                    module: None,
-                });
-            }
-            if let Some((module_name, original)) = imports.from_imports.get(&name.id)
-                && let Some(class_ref) = imported_class_ref(
-                    module_name,
-                    original,
-                    module_cache.as_deref_mut(),
-                    module_path,
-                )
-            {
-                return Some(class_ref);
-            }
-        }
-        Expr::Attribute(attr) => {
-            if let Expr::Name(module_ident) = attr.value.as_ref()
-                && let Some(module_name) = imports.module_aliases.get(&module_ident.id)
-                && let Some(class_ref) =
-                    imported_class_ref(module_name, &attr.attr, module_cache, module_path)
-            {
-                return Some(class_ref);
-            }
-        }
-        _ => {}
-    }
-    None
 }
 
 fn find_project_root(start: &Path) -> Option<PathBuf> {

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -6,11 +6,15 @@
 //! - and cache that work across LSP requests.
 
 use crate::VarState;
+use crate::expr_text_range;
 use crate::infer::infer_creation_size;
 use crate::infer_expr_shape;
 use crate::normalize_return_annotations;
 use crate::op_groups::{Imports, TorchOp, collect_imports};
+use crate::text_range_to_lsp;
 use crate::torch_nn::{TorchNNModule, module_from_constructor_call};
+use lsp_types::Diagnostic;
+use lsp_types::DiagnosticSeverity;
 use rustpython_parser::Parse;
 use rustpython_parser::ast::{Arguments, Expr, ExprCall, Identifier, Stmt, Suite};
 use std::cell::OnceCell;
@@ -456,6 +460,7 @@ pub(crate) fn resolved_module_from_expr<'a>(
     func_map: &FuncMap,
     imports: &Imports,
     class_map: &ClassMap,
+    diagnostics: &mut Vec<Diagnostic>,
     mut module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<ResolvedModuleRef<'a>> {
@@ -466,6 +471,24 @@ pub(crate) fn resolved_module_from_expr<'a>(
         module_cache.as_deref_mut(),
         module_path,
     ) {
+        if matches!(
+            resolved_module,
+            ResolvedModule::Builtin(TorchNNModule::Unknown)
+        ) {
+            // TODO(carrascomj): consider if this is too annoying for users
+            diagnostics.push(Diagnostic {
+                range: text_range_to_lsp(expr_text_range(expr), source),
+                severity: Some(DiagnosticSeverity::INFORMATION),
+                code: None,
+                code_description: None,
+                source: Some("shapels".into()),
+                message: "Module not yet understood by shapels (treated as Noop)".to_string(),
+                related_information: None,
+                tags: None,
+                data: None,
+            });
+        }
+
         return Some(ResolvedModuleRef::Owned(resolved_module));
     }
     resolve_module_expr(

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -13,7 +13,7 @@ use crate::op_groups::{Imports, TorchOp, collect_imports};
 use crate::torch_nn::{TorchNNModule, module_from_constructor_call};
 use rustpython_parser::Parse;
 use rustpython_parser::ast::{Arguments, Expr, ExprCall, Identifier, Stmt, Suite};
-use std::cell::RefCell;
+use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -42,7 +42,8 @@ pub(crate) struct ClassInfo {
     pub(crate) is_torch_module: bool,
     pub(crate) forward_name: Option<Identifier>,
     pub(crate) methods: HashMap<Identifier, FunctionInfo>,
-    self_attr_states: RefCell<Option<HashMap<Identifier, VarState>>>,
+    self_attr_states: OnceCell<HashMap<Identifier, VarState>>,
+    self_attr_modules: OnceCell<HashMap<Identifier, Rc<ResolvedModule>>>,
 }
 
 pub(crate) type ClassMap = HashMap<Identifier, ClassInfo>;
@@ -351,7 +352,8 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
                     is_torch_module: is_torch.get(&name).copied().unwrap_or(false),
                     forward_name: info.forward_name,
                     methods: info.methods,
-                    self_attr_states: RefCell::new(None),
+                    self_attr_states: OnceCell::new(),
+                    self_attr_modules: OnceCell::new(),
                 },
             )
         })
@@ -361,6 +363,7 @@ pub(crate) fn collect_class_defs(body: &[Stmt], imports: &Imports) -> ClassMap {
 pub(crate) enum ResolvedModuleRef<'a> {
     Borrowed(&'a ResolvedModule),
     Owned(ResolvedModule),
+    Shared(Rc<ResolvedModule>),
 }
 
 impl<'a> ResolvedModuleRef<'a> {
@@ -368,6 +371,7 @@ impl<'a> ResolvedModuleRef<'a> {
         match self {
             Self::Borrowed(module) => module,
             Self::Owned(module) => module,
+            Self::Shared(module) => module.as_ref(),
         }
     }
 
@@ -375,6 +379,7 @@ impl<'a> ResolvedModuleRef<'a> {
         match self {
             Self::Borrowed(module) => module.clone(),
             Self::Owned(module) => module,
+            Self::Shared(module) => module.as_ref().clone(),
         }
     }
 }
@@ -761,22 +766,69 @@ fn get_or_collect_self_attr_state(
     module_cache: Option<&mut ModuleCache>,
     module_path: Option<&Path>,
 ) -> Option<VarState> {
-    if class_info.self_attr_states.borrow().is_none() {
-        let states = collect_self_attr_states_from_init(
+    self_attr_states(
+        class_info,
+        source,
+        class_map,
+        imports,
+        module_cache,
+        module_path,
+    )
+    .get(target_attr)
+    .cloned()
+}
+
+fn self_attr_states<'a>(
+    class_info: &'a ClassInfo,
+    source: &str,
+    class_map: &ClassMap,
+    imports: &Imports,
+    module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> &'a HashMap<Identifier, VarState> {
+    class_info.self_attr_states.get_or_init(|| {
+        collect_self_attr_states_from_init(
             class_info.methods.get(&Identifier::from("__init__")),
             source,
             class_map,
             imports,
             module_cache,
             module_path,
-        );
-        *class_info.self_attr_states.borrow_mut() = Some(states);
-    }
+        )
+    })
+}
+
+fn get_or_collect_self_attr_module(
+    class_info: &ClassInfo,
+    target_attr: &Identifier,
+    source: &str,
+    class_map: &ClassMap,
+    imports: &Imports,
+    module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<Rc<ResolvedModule>> {
     class_info
-        .self_attr_states
-        .borrow()
-        .as_ref()
-        .and_then(|states| states.get(target_attr))
+        .self_attr_modules
+        .get_or_init(|| {
+            self_attr_states(
+                class_info,
+                source,
+                class_map,
+                imports,
+                module_cache,
+                module_path,
+            )
+            .iter()
+            .filter_map(|(attr, state)| {
+                state
+                    .resolved_module
+                    .as_ref()
+                    .cloned()
+                    .map(|module| (attr.clone(), Rc::new(module)))
+            })
+            .collect()
+        })
+        .get(target_attr)
         .cloned()
 }
 
@@ -817,6 +869,71 @@ fn resolve_cached_self_attr_state(
         },
     )
     .flatten()
+}
+
+fn resolve_cached_self_attr_module(
+    base_class_ref: &ClassRef,
+    target_attr: &Identifier,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    module_cache: &mut Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<Rc<ResolvedModule>> {
+    with_class_info(
+        base_class_ref,
+        source,
+        func_map,
+        imports,
+        class_map,
+        module_cache,
+        module_path,
+        |class_info,
+         callee_source,
+         _callee_func_map,
+         callee_imports,
+         callee_class_map,
+         callee_path,
+         module_cache| {
+            get_or_collect_self_attr_module(
+                class_info,
+                target_attr,
+                callee_source,
+                callee_class_map,
+                callee_imports,
+                module_cache.as_deref_mut(),
+                callee_path,
+            )
+        },
+    )
+    .flatten()
+}
+
+pub(crate) fn self_attr_module_from_self(
+    target_attr: &Identifier,
+    vars: &HashMap<Identifier, VarState>,
+    source: &str,
+    func_map: &FuncMap,
+    imports: &Imports,
+    class_map: &ClassMap,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<Rc<ResolvedModule>> {
+    let self_class_ref = vars
+        .get(&Identifier::from("self"))
+        .and_then(|state| state.resolved_module.as_ref())
+        .and_then(ResolvedModule::as_user)?;
+    resolve_cached_self_attr_module(
+        self_class_ref,
+        target_attr,
+        source,
+        func_map,
+        imports,
+        class_map,
+        &mut module_cache,
+        module_path,
+    )
 }
 
 /// Resolve an attribute access such as `self.weight` to the cached state from `__init__`.
@@ -881,7 +998,7 @@ fn resolve_module_expr<'a>(
                 module_cache.as_deref_mut(),
                 module_path,
             )?;
-            resolve_cached_self_attr_state(
+            resolve_cached_self_attr_module(
                 base_module.as_ref().as_user()?,
                 &attr.attr,
                 source,
@@ -891,8 +1008,7 @@ fn resolve_module_expr<'a>(
                 &mut module_cache,
                 module_path,
             )
-            .and_then(|state| state.resolved_module)
-            .map(ResolvedModuleRef::Owned)
+            .map(ResolvedModuleRef::Shared)
         }
         _ => None,
     }

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -261,7 +261,7 @@ fn is_torch_nn_module_base(expr: &Expr, imports: &Imports) -> bool {
     let Expr::Attribute(attr) = expr else {
         return false;
     };
-    attr.attr.as_str() == "Module" && is_torch_nn_namespace(attr.value.as_ref(), imports)
+    attr.attr.as_str() == "Module" && imports.is_torch_nn_namespace_expr(attr.value.as_ref())
 }
 
 /// Collect class definitions and mark which ones inherit from `torch.nn.Module`.
@@ -510,22 +510,6 @@ fn module_state(resolved_module: ResolvedModule) -> VarState {
     }
 }
 
-fn is_torch_namespace(expr: &Expr, imports: &Imports) -> bool {
-    matches!(expr, Expr::Name(name) if imports.torch_aliases.contains(&name.id))
-}
-
-pub(crate) fn is_torch_nn_namespace(expr: &Expr, imports: &Imports) -> bool {
-    match expr {
-        Expr::Name(name) => imports.is_module_alias(&name.id, "torch.nn"),
-        Expr::Attribute(attr)
-            if attr.attr.as_str() == "nn" && is_torch_namespace(attr.value.as_ref(), imports) =>
-        {
-            true
-        }
-        _ => false,
-    }
-}
-
 pub(crate) fn imported_class_ref(
     module_name: &str,
     class_name: &Identifier,
@@ -546,22 +530,13 @@ pub(crate) fn imported_class_ref(
 }
 
 pub(crate) fn is_parameter_constructor(func: &Expr, imports: &Imports) -> bool {
-    match func {
-        Expr::Name(name) => imports
-            .imported_symbol_from(&name.id, "torch.nn")
-            .map(|original| original.as_str() == "Parameter")
-            .unwrap_or(false),
-        Expr::Attribute(attr) => {
-            attr.attr.as_str() == "Parameter" && is_torch_nn_namespace(attr.value.as_ref(), imports)
-        }
-        _ => false,
-    }
+    imports.is_torch_nn_storage_constructor(func)
 }
 
 fn torch_call_op(func: &Expr, imports: &Imports) -> TorchOp {
     match func {
         Expr::Name(name) => TorchOp::as_call(&name.id, imports),
-        Expr::Attribute(attr) if is_torch_namespace(attr.value.as_ref(), imports) => {
+        Expr::Attribute(attr) if imports.is_torch_namespace_expr(attr.value.as_ref()) => {
             TorchOp::from_attr(attr.attr.as_str())
         }
         _ => TorchOp::Unknown,

--- a/src/module_resolution.rs
+++ b/src/module_resolution.rs
@@ -552,10 +552,6 @@ pub(crate) fn imported_class_ref(
     })
 }
 
-pub(crate) fn is_parameter_constructor(func: &Expr, imports: &Imports) -> bool {
-    imports.is_torch_nn_storage_constructor(func)
-}
-
 fn torch_call_op(func: &Expr, imports: &Imports) -> TorchOp {
     match func {
         Expr::Name(name) => TorchOp::as_call(&name.id, imports),
@@ -615,7 +611,7 @@ fn infer_tracked_state_from_expr(
     }
 
     if let Expr::Call(call) = expr {
-        if is_parameter_constructor(call.func.as_ref(), imports) {
+        if imports.is_torch_nn_storage_constructor(call.func.as_ref()) {
             let first_arg = call.args.first()?;
             return infer_tracked_state_from_expr(
                 first_arg,

--- a/src/op_groups.rs
+++ b/src/op_groups.rs
@@ -7,6 +7,7 @@ use phf::Set;
 use phf_macros::phf_set;
 use rustpython_parser::ast::{Expr, Identifier, Stmt, StmtImportFrom};
 
+use crate::torch_nn::known_nn_modules::NOOP_NN_MODULES;
 use crate::{infer::Transpose, is_alias_of};
 
 /// Torch functions and operations whose inference is supported.
@@ -520,6 +521,8 @@ pub struct Imports {
     pub torch_nn_functional_aliases: HashSet<Identifier>,
     /// Direct imports of `torch.nn.Parameter` or `torch.nn.Buffer`.
     pub torch_nn_storage_aliases: HashSet<Identifier>,
+    /// Noop `torch.nn.Module`s imported into the current scope.
+    pub torch_nn_noop_aliases: HashMap<Identifier, Identifier>,
     /// Maps simple function name (e.g., "mm") to all aliases in scope.
     pub func_aliases: HashMap<&'static str, HashSet<Identifier>>,
     /// Module alias mapping for `import foo as bar` style.
@@ -531,6 +534,10 @@ pub struct Imports {
 impl Imports {
     fn is_torch_nn_storage_name(name: &str) -> bool {
         matches!(name, "Parameter" | "Buffer")
+    }
+
+    fn record_torch_nn_noop_alias(&mut self, alias: Identifier, original: Identifier) {
+        self.torch_nn_noop_aliases.insert(alias, original);
     }
 
     pub(crate) fn imported_symbol_from<'a>(
@@ -548,6 +555,13 @@ impl Imports {
             .get(ident)
             .map(|module| module == module_name)
             .unwrap_or(false)
+    }
+
+    pub(crate) fn imported_torch_nn_noop<'a>(
+        &'a self,
+        ident: &Identifier,
+    ) -> Option<&'a Identifier> {
+        self.torch_nn_noop_aliases.get(ident)
     }
 
     pub(crate) fn is_torch_namespace_expr(&self, expr: &Expr) -> bool {
@@ -659,6 +673,8 @@ pub fn collect_imports(
             Stmt::ImportFrom(f) => {
                 let resolved_module = resolve_from_module(f, module_path, project_root);
                 if let Some(module) = &resolved_module {
+                    let is_torch_nn_module_path = module == "torch.nn"
+                        || (module.starts_with("torch.nn.") && module != "torch.nn.functional");
                     for alias in &f.names {
                         let name = alias.name.as_str();
                         let id = alias
@@ -666,10 +682,22 @@ pub fn collect_imports(
                             .clone()
                             .unwrap_or_else(|| Identifier::from(name));
 
+                        if is_torch_nn_module_path && name == "*" {
+                            for noop_name in &NOOP_NN_MODULES {
+                                let ident = Identifier::from(*noop_name);
+                                imports.record_torch_nn_noop_alias(ident.clone(), ident);
+                            }
+                            continue;
+                        }
+
                         if matches!(module.as_str(), "torch.nn" | "torch.nn.parameter")
                             && Imports::is_torch_nn_storage_name(name)
                         {
                             imports.torch_nn_storage_aliases.insert(id.clone());
+                        }
+
+                        if is_torch_nn_module_path && NOOP_NN_MODULES.contains(name) {
+                            imports.record_torch_nn_noop_alias(id.clone(), alias.name.clone());
                         }
 
                         if module == "torch" && name == "nn" {

--- a/src/op_groups.rs
+++ b/src/op_groups.rs
@@ -526,6 +526,25 @@ pub struct Imports {
     pub from_imports: HashMap<Identifier, (String, Identifier)>,
 }
 
+impl Imports {
+    pub(crate) fn imported_symbol_from<'a>(
+        &'a self,
+        ident: &Identifier,
+        module_name: &str,
+    ) -> Option<&'a Identifier> {
+        self.from_imports
+            .get(ident)
+            .and_then(|(module, original)| (module == module_name).then_some(original))
+    }
+
+    pub(crate) fn is_module_alias(&self, ident: &Identifier, module_name: &str) -> bool {
+        self.module_aliases
+            .get(ident)
+            .map(|module| module == module_name)
+            .unwrap_or(false)
+    }
+}
+
 /// Map all known operations to their importing aliases, for instance:
 ///
 /// ```python
@@ -605,18 +624,36 @@ pub fn collect_imports(
             }
             Stmt::ImportFrom(f) => {
                 let resolved_module = resolve_from_module(f, module_path, project_root);
-                if let Some(module) = &resolved_module
-                    && (module == "torch" || module == "torch.nn.functional")
-                {
+                if let Some(module) = &resolved_module {
                     for alias in &f.names {
                         let name = alias.name.as_str();
-                        if let Some(val) = imports.func_aliases.get_mut(name) {
-                            let id = alias
-                                .asname
-                                .clone()
-                                .unwrap_or_else(|| Identifier::from(name));
-                            val.insert(id);
-                        } else {
+                        let id = alias
+                            .asname
+                            .clone()
+                            .unwrap_or_else(|| Identifier::from(name));
+
+                        if module == "torch" && name == "nn" {
+                            imports
+                                .module_aliases
+                                .insert(id.clone(), "torch.nn".to_string());
+                            continue;
+                        }
+
+                        if module == "torch.nn" && name == "functional" {
+                            imports
+                                .module_aliases
+                                .insert(id.clone(), "torch.nn.functional".to_string());
+                            imports.torch_nn_functional_aliases.insert(id.clone());
+                            continue;
+                        }
+
+                        if module == "torch" || module == "torch.nn.functional" {
+                            if let Some(val) = imports.func_aliases.get_mut(name) {
+                                val.insert(id);
+                                continue;
+                            }
+
+                            let mut handled = false;
                             for (container, key) in [
                                 (&AGGR_ALIASES, "sum"),
                                 (&NOOP_DIM_ALIASES, "softmax"),
@@ -631,21 +668,19 @@ pub fn collect_imports(
                                 (&QUANTILE_ALIASES, "quantile"),
                             ] {
                                 if container.contains(name) {
-                                    let id = alias
-                                        .asname
-                                        .clone()
-                                        .unwrap_or_else(|| Identifier::from(name));
-                                    imports.func_aliases.entry(key).or_default().insert(id);
+                                    imports
+                                        .func_aliases
+                                        .entry(key)
+                                        .or_default()
+                                        .insert(id.clone());
+                                    handled = true;
                                 }
                             }
+                            if handled {
+                                continue;
+                            }
                         }
-                    }
-                } else if let Some(module) = &resolved_module {
-                    for alias in &f.names {
-                        let id = alias
-                            .asname
-                            .clone()
-                            .unwrap_or_else(|| Identifier::from(alias.name.as_str()));
+
                         imports
                             .from_imports
                             .insert(id, (module.to_string(), alias.name.clone()));

--- a/src/op_groups.rs
+++ b/src/op_groups.rs
@@ -5,7 +5,7 @@ use std::{
 
 use phf::Set;
 use phf_macros::phf_set;
-use rustpython_parser::ast::{Identifier, Stmt, StmtImportFrom};
+use rustpython_parser::ast::{Expr, Identifier, Stmt, StmtImportFrom};
 
 use crate::{infer::Transpose, is_alias_of};
 
@@ -518,6 +518,8 @@ pub struct Imports {
     pub torch_aliases: HashSet<Identifier>,
     // e.g., `import torch.nn.functional as F`
     pub torch_nn_functional_aliases: HashSet<Identifier>,
+    /// Direct imports of `torch.nn.Parameter` or `torch.nn.Buffer`.
+    pub torch_nn_storage_aliases: HashSet<Identifier>,
     /// Maps simple function name (e.g., "mm") to all aliases in scope.
     pub func_aliases: HashMap<&'static str, HashSet<Identifier>>,
     /// Module alias mapping for `import foo as bar` style.
@@ -527,6 +529,10 @@ pub struct Imports {
 }
 
 impl Imports {
+    fn is_torch_nn_storage_name(name: &str) -> bool {
+        matches!(name, "Parameter" | "Buffer")
+    }
+
     pub(crate) fn imported_symbol_from<'a>(
         &'a self,
         ident: &Identifier,
@@ -542,6 +548,34 @@ impl Imports {
             .get(ident)
             .map(|module| module == module_name)
             .unwrap_or(false)
+    }
+
+    pub(crate) fn is_torch_namespace_expr(&self, expr: &Expr) -> bool {
+        matches!(expr, Expr::Name(name) if self.torch_aliases.contains(&name.id))
+    }
+
+    pub(crate) fn is_torch_nn_namespace_expr(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Name(name) => self.is_module_alias(&name.id, "torch.nn"),
+            Expr::Attribute(attr)
+                if attr.attr.as_str() == "nn"
+                    && self.is_torch_namespace_expr(attr.value.as_ref()) =>
+            {
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_torch_nn_storage_constructor(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Name(name) => self.torch_nn_storage_aliases.contains(&name.id),
+            Expr::Attribute(attr) => {
+                Self::is_torch_nn_storage_name(attr.attr.as_str())
+                    && self.is_torch_nn_namespace_expr(attr.value.as_ref())
+            }
+            _ => false,
+        }
     }
 }
 
@@ -631,6 +665,12 @@ pub fn collect_imports(
                             .asname
                             .clone()
                             .unwrap_or_else(|| Identifier::from(name));
+
+                        if matches!(module.as_str(), "torch.nn" | "torch.nn.parameter")
+                            && Imports::is_torch_nn_storage_name(name)
+                        {
+                            imports.torch_nn_storage_aliases.insert(id.clone());
+                        }
 
                         if module == "torch" && name == "nn" {
                             imports

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -249,3 +249,19 @@ fn imported_parameter_and_buffer_are_tracked() {
     assert_eq!(analysis.diagnostics.len(), 0);
     assert!(is_hover_expected(&src, &analysis, "y =", "B X 57"));
 }
+
+#[test]
+fn imported_aliased_noop_module_is_resolved() {
+    let src = extract_test_case(PY_DATA, 30);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "y =", "B X 32"));
+}
+
+#[test]
+fn imported_star_noop_module_is_resolved() {
+    let src = extract_test_case(PY_DATA, 31);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "y =", "B X 32"));
+}

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -196,7 +196,7 @@ fn annotated_ellipsis_instantiates_tuple_destructuring() {
 }
 
 #[test]
-fn linear_module_should_shape_chgck() {
+fn linear_module_should_shape_check() {
     let src = extract_test_case(PY_DATA, 23);
     let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert_eq!(analysis.diagnostics.len(), 0);
@@ -204,7 +204,7 @@ fn linear_module_should_shape_chgck() {
 }
 
 #[test]
-fn linear_module_abstract_should_shape_chgck() {
+fn linear_module_abstract_should_shape_check() {
     let src = extract_test_case(PY_DATA, 24);
     let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert_eq!(analysis.diagnostics.len(), 0);
@@ -219,7 +219,7 @@ fn wrong_shape_should_emit_diagnostic_for_linear_module() {
 }
 
 #[test]
-fn alpha_equiv_concret_to_abstract_shape_checks() {
+fn alpha_equiv_concrete_to_abstract_shape_checks() {
     let src = extract_test_case(PY_DATA, 26);
     let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert_eq!(analysis.diagnostics.len(), 0);
@@ -227,7 +227,7 @@ fn alpha_equiv_concret_to_abstract_shape_checks() {
 }
 
 #[test]
-fn sequential_cov_model_shape_checks() {
+fn sequential_conv_model_shape_checks() {
     let src = extract_test_case(PY_DATA, 27);
     let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert_eq!(analysis.diagnostics.len(), 0);

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -241,3 +241,11 @@ fn wrong_input_to_sequential_cov_model_emits_diagnostics() {
     let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
     assert_eq!(analysis.diagnostics.len(), 1);
 }
+
+#[test]
+fn imported_parameter_and_buffer_are_tracked() {
+    let src = extract_test_case(PY_DATA, 29);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "y =", "B X 57"));
+}

--- a/src/tests/test_class.rs
+++ b/src/tests/test_class.rs
@@ -194,3 +194,50 @@ fn annotated_ellipsis_instantiates_tuple_destructuring() {
         "Batch Heads Tokens Embed"
     ));
 }
+
+#[test]
+fn linear_module_should_shape_chgck() {
+    let src = extract_test_case(PY_DATA, 23);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "z =", "B X 11"));
+}
+
+#[test]
+fn linear_module_abstract_should_shape_chgck() {
+    let src = extract_test_case(PY_DATA, 24);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "z =", "B X Z"));
+}
+
+#[test]
+fn wrong_shape_should_emit_diagnostic_for_linear_module() {
+    let src = extract_test_case(PY_DATA, 25);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 1);
+}
+
+#[test]
+fn alpha_equiv_concret_to_abstract_shape_checks() {
+    let src = extract_test_case(PY_DATA, 26);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    assert!(is_hover_expected(&src, &analysis, "z =", "B X 12"));
+}
+
+#[test]
+fn sequential_cov_model_shape_checks() {
+    let src = extract_test_case(PY_DATA, 27);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 0);
+    // TODO: check that output H W are correct
+    assert!(is_hover_expected(&src, &analysis, "y =", "B OutCh H W"));
+}
+
+#[test]
+fn wrong_input_to_sequential_cov_model_emits_diagnostics() {
+    let src = extract_test_case(PY_DATA, 28);
+    let analysis = analyze_source_at_path(&src, Path::new("test_data/class.py"));
+    assert_eq!(analysis.diagnostics.len(), 1);
+}

--- a/src/tests/test_conv.rs
+++ b/src/tests/test_conv.rs
@@ -51,3 +51,52 @@ fn wrong_input_for_conv1d() {
     let analysis = analyze_source(&src);
     assert_eq!(analysis.diagnostics.len(), 1);
 }
+
+#[test]
+fn conv1d_module_with_concrete_dims() {
+    let src = extract_test_case(PY_DATA, 6);
+    let analysis = analyze_source(&src);
+    assert!(analysis.diagnostics.is_empty());
+    assert!(is_hover_expected(&src, &analysis, "out =", "32 128 510"));
+}
+
+#[test]
+fn conv2d_module_with_mixed_dims() {
+    let src = extract_test_case(PY_DATA, 7);
+    let analysis = analyze_source(&src);
+    assert!(analysis.diagnostics.is_empty());
+    assert!(is_hover_expected(
+        &src,
+        &analysis,
+        "y =",
+        "32 128 (H+5)/2+1 (W+5)/2+1"
+    ));
+}
+
+#[test]
+fn conv3d_module_with_concrete_dims() {
+    let src = extract_test_case(PY_DATA, 8);
+    let analysis = analyze_source(&src);
+    assert!(analysis.diagnostics.is_empty());
+    assert!(is_hover_expected(&src, &analysis, "y =", "2 8 10 9 128"));
+}
+
+#[test]
+fn conv3d_module_with_mixed_dims() {
+    let src = extract_test_case(PY_DATA, 9);
+    let analysis = analyze_source(&src);
+    assert!(analysis.diagnostics.is_empty());
+    assert!(is_hover_expected(
+        &src,
+        &analysis,
+        "y =",
+        "2 8 19/S+1 (29+2*P-D*4)/3+1 10"
+    ));
+}
+
+#[test]
+fn wrong_input_for_conv1d_module() {
+    let src = extract_test_case(PY_DATA, 10);
+    let analysis = analyze_source(&src);
+    assert_eq!(analysis.diagnostics.len(), 2);
+}

--- a/src/torch_nn.rs
+++ b/src/torch_nn.rs
@@ -47,66 +47,29 @@ pub(crate) fn module_from_constructor_call(
         return None;
     };
 
-    match call.func.as_ref() {
-        Expr::Name(name) => {
-            if class_map.contains_key(&name.id) {
-                return Some(ResolvedModule::User(ClassRef {
-                    name: name.id.clone(),
-                    module: None,
-                }));
-            }
-            if let Some((module_name, original)) = imports.from_imports.get(&name.id) {
-                if module_name == "torch.nn" {
-                    if original.as_str() == "Parameter" {
-                        return None;
-                    }
-                    return Some(ResolvedModule::Builtin(
-                        TorchNNModule::from_constructor_call(
-                            call_expr,
-                            class_map,
-                            imports,
-                            module_cache,
-                            module_path,
-                        ),
-                    ));
-                }
-                if let Some(class_ref) = imported_class_ref(
-                    module_name,
-                    original,
-                    module_cache.as_deref_mut(),
-                    module_path,
-                ) {
-                    return Some(ResolvedModule::User(class_ref));
-                }
-            }
-        }
-        Expr::Attribute(attr) => {
-            if is_torch_nn_constructor(call_expr, imports) {
-                if attr.attr.as_str() == "Parameter" {
-                    return None;
-                }
-                return Some(ResolvedModule::Builtin(
-                    TorchNNModule::from_constructor_call(
-                        call_expr,
-                        class_map,
-                        imports,
-                        module_cache,
-                        module_path,
-                    ),
-                ));
-            }
-            if let Expr::Name(module_ident) = attr.value.as_ref()
-                && let Some(module_name) = imports.module_aliases.get(&module_ident.id)
-                && let Some(class_ref) =
-                    imported_class_ref(module_name, &attr.attr, module_cache, module_path)
-            {
-                return Some(ResolvedModule::User(class_ref));
-            }
-        }
-        _ => {}
+    if let Some(class_ref) = constructor_class_ref(
+        call.func.as_ref(),
+        class_map,
+        imports,
+        module_cache.as_deref_mut(),
+        module_path,
+    ) {
+        return Some(ResolvedModule::User(class_ref));
     }
 
-    None
+    let constructor_name = torch_nn_constructor_name(call_expr, imports)?;
+    if constructor_name == "Parameter" {
+        return None;
+    }
+    Some(ResolvedModule::Builtin(
+        TorchNNModule::from_constructor_call(
+            call_expr,
+            class_map,
+            imports,
+            module_cache,
+            module_path,
+        ),
+    ))
 }
 
 impl TorchNNModule {
@@ -114,7 +77,7 @@ impl TorchNNModule {
         call_expr: &Expr,
         class_map: &ClassMap,
         imports: &Imports,
-        mut module_cache: Option<&mut ModuleCache>,
+        module_cache: Option<&mut ModuleCache>,
         module_path: Option<&Path>,
     ) -> Self {
         let Expr::Call(call) = call_expr else {
@@ -123,6 +86,24 @@ impl TorchNNModule {
         let Some(constructor_name) = torch_nn_constructor_name(call_expr, imports) else {
             return Self::Noop;
         };
+        Self::from_named_constructor(
+            call,
+            &constructor_name,
+            class_map,
+            imports,
+            module_cache,
+            module_path,
+        )
+    }
+
+    fn from_named_constructor(
+        call: &ExprCall,
+        constructor_name: &str,
+        class_map: &ClassMap,
+        imports: &Imports,
+        mut module_cache: Option<&mut ModuleCache>,
+        module_path: Option<&Path>,
+    ) -> Self {
         let normalized = constructor_name.to_ascii_lowercase();
 
         if normalized == "linear" {
@@ -165,19 +146,20 @@ impl TorchNNModule {
         }
 
         if normalized == "sequential" {
-            let mut modules = Vec::new();
-            for element in sequential_elements(call) {
-                if let Some(module) = module_from_constructor_call(
-                    element,
-                    class_map,
-                    imports,
-                    module_cache.as_deref_mut(),
-                    module_path,
-                ) {
-                    modules.push(module);
-                }
-            }
-            return Self::Sequential(modules);
+            return Self::Sequential(
+                sequential_elements(call)
+                    .into_iter()
+                    .filter_map(|element| {
+                        module_from_constructor_call(
+                            element,
+                            class_map,
+                            imports,
+                            module_cache.as_deref_mut(),
+                            module_path,
+                        )
+                    })
+                    .collect(),
+            );
         }
 
         Self::Noop
@@ -276,8 +258,33 @@ fn get_call_arg<'a>(call: &'a ExprCall, name_arg: &str, as_positional: usize) ->
     })
 }
 
-fn is_torch_nn_constructor(call_expr: &Expr, imports: &Imports) -> bool {
-    torch_nn_constructor_name(call_expr, imports).is_some()
+fn constructor_class_ref(
+    constructor: &Expr,
+    class_map: &ClassMap,
+    imports: &Imports,
+    module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ClassRef> {
+    match constructor {
+        Expr::Name(name) => {
+            if class_map.contains_key(&name.id) {
+                return Some(ClassRef {
+                    name: name.id.clone(),
+                    module: None,
+                });
+            }
+            let (module_name, original) = imports.from_imports.get(&name.id)?;
+            imported_class_ref(module_name, original, module_cache, module_path)
+        }
+        Expr::Attribute(attr) => {
+            let Expr::Name(module_ident) = attr.value.as_ref() else {
+                return None;
+            };
+            let module_name = imports.module_aliases.get(&module_ident.id)?;
+            imported_class_ref(module_name, &attr.attr, module_cache, module_path)
+        }
+        _ => None,
+    }
 }
 
 fn torch_nn_constructor_name(call_expr: &Expr, imports: &Imports) -> Option<String> {

--- a/src/torch_nn.rs
+++ b/src/torch_nn.rs
@@ -1,3 +1,6 @@
+use crate::expr_tokens::{
+    MODULE_ARG_TOKEN_OPTIONS, expr_to_symbolic_token, expr_to_symbolic_tokens,
+};
 use crate::infer::{infer_batchnorm_module, infer_conv_module, infer_linear_module};
 use crate::module_resolution::{
     ClassMap, ClassRef, FuncMap, ModuleCache, ResolvedModule, imported_class_ref,
@@ -6,7 +9,7 @@ use crate::module_resolution::{
 use crate::op_groups::Imports;
 use crate::{HoverInfo, Shape, VarState, infer_resolved_module_shape};
 use lsp_types::{Diagnostic, Range};
-use rustpython_parser::ast::{Expr, ExprCall, Identifier, Operator};
+use rustpython_parser::ast::{Expr, ExprCall, Identifier};
 use rustpython_parser::text_size::TextRange;
 use std::collections::HashMap;
 use std::path::Path;
@@ -59,7 +62,7 @@ pub(crate) fn module_from_constructor_call(
     }
 
     let constructor_name = torch_nn_constructor_name(call_expr, imports)?;
-    if constructor_name == "Parameter" {
+    if constructor_name == "Parameter" || constructor_name == "Buffer" {
         return None;
     }
     Some(ResolvedModule::Builtin(
@@ -109,8 +112,8 @@ impl TorchNNModule {
 
         if normalized == "linear" {
             return Self::Linear {
-                in_features: get_call_arg(call, "in_features", 0).and_then(expr_to_token),
-                out_features: get_call_arg(call, "out_features", 1).and_then(expr_to_token),
+                in_features: get_call_arg(call, "in_features", 0).and_then(module_arg_token),
+                out_features: get_call_arg(call, "out_features", 1).and_then(module_arg_token),
             };
         }
 
@@ -119,7 +122,7 @@ impl TorchNNModule {
         {
             return Self::BatchNorm {
                 dims,
-                num_features: get_call_arg(call, "num_features", 0).and_then(expr_to_token),
+                num_features: get_call_arg(call, "num_features", 0).and_then(module_arg_token),
             };
         }
 
@@ -128,21 +131,21 @@ impl TorchNNModule {
         {
             return Self::Conv {
                 dims,
-                in_channels: get_call_arg(call, "in_channels", 0).and_then(expr_to_token),
-                out_channels: get_call_arg(call, "out_channels", 1).and_then(expr_to_token),
+                in_channels: get_call_arg(call, "in_channels", 0).and_then(module_arg_token),
+                out_channels: get_call_arg(call, "out_channels", 1).and_then(module_arg_token),
                 kernel_size: get_call_arg(call, "kernel_size", 2)
-                    .and_then(expr_to_tokens)
+                    .and_then(module_arg_tokens)
                     .unwrap_or_default(),
                 stride: get_call_arg(call, "stride", 3)
-                    .and_then(expr_to_tokens)
+                    .and_then(module_arg_tokens)
                     .unwrap_or_default(),
                 padding: get_call_arg(call, "padding", 4)
-                    .and_then(expr_to_tokens)
+                    .and_then(module_arg_tokens)
                     .unwrap_or_default(),
                 dilation: get_call_arg(call, "dilation", 5)
-                    .and_then(expr_to_tokens)
+                    .and_then(module_arg_tokens)
                     .unwrap_or_default(),
-                groups: get_call_arg(call, "groups", 6).and_then(expr_to_token),
+                groups: get_call_arg(call, "groups", 6).and_then(module_arg_token),
             };
         }
 
@@ -321,51 +324,10 @@ fn sequential_elements(call: &ExprCall) -> Vec<&Expr> {
     call.args.iter().collect()
 }
 
-fn expr_to_tokens(expr: &Expr) -> Option<Vec<String>> {
-    match expr {
-        Expr::Tuple(tuple) => tuple.elts.iter().map(expr_to_token).collect(),
-        Expr::List(list) => list.elts.iter().map(expr_to_token).collect(),
-        other => expr_to_token(other).map(|token| vec![token]),
-    }
+fn module_arg_token(expr: &Expr) -> Option<String> {
+    expr_to_symbolic_token(expr, MODULE_ARG_TOKEN_OPTIONS).map(|token| token.into_owned())
 }
 
-fn expr_to_token(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::Name(name) => Some(name.id.to_string()),
-        Expr::Constant(constant) => match &constant.value {
-            rustpython_parser::ast::Constant::Int(int) => Some(int.to_string()),
-            rustpython_parser::ast::Constant::Float(float) => Some(float.to_string()),
-            rustpython_parser::ast::Constant::Str(string) => Some(string.to_string()),
-            _ => None,
-        },
-        Expr::Attribute(attr) => Some(attr.attr.to_string()),
-        Expr::UnaryOp(unary) => match unary.op {
-            rustpython_parser::ast::UnaryOp::USub => {
-                expr_to_token(unary.operand.as_ref()).map(|token| format!("-{token}"))
-            }
-            rustpython_parser::ast::UnaryOp::UAdd => expr_to_token(unary.operand.as_ref()),
-            _ => None,
-        },
-        Expr::BinOp(bin) => {
-            let left = expr_to_token(bin.left.as_ref())?;
-            let right = expr_to_token(bin.right.as_ref())?;
-            let op = match bin.op {
-                Operator::Add => "+",
-                Operator::Sub => "-",
-                Operator::Mult => "*",
-                Operator::Div | Operator::FloorDiv => "/",
-                _ => return None,
-            };
-            Some(format!("{left}{op}{right}"))
-        }
-        Expr::Call(call) => {
-            if let Expr::Name(name) = call.func.as_ref()
-                && name.id.as_str() == "int"
-            {
-                return call.args.first().and_then(expr_to_token);
-            }
-            None
-        }
-        _ => None,
-    }
+fn module_arg_tokens(expr: &Expr) -> Option<Vec<String>> {
+    expr_to_symbolic_tokens(expr, MODULE_ARG_TOKEN_OPTIONS)
 }

--- a/src/torch_nn.rs
+++ b/src/torch_nn.rs
@@ -4,7 +4,6 @@ use crate::expr_tokens::{
 use crate::infer::{infer_batchnorm_module, infer_conv_module, infer_linear_module};
 use crate::module_resolution::{
     ClassMap, ClassRef, FuncMap, ModuleCache, ResolvedModule, imported_class_ref,
-    is_torch_nn_namespace,
 };
 use crate::op_groups::Imports;
 use crate::{HoverInfo, Shape, VarState, infer_resolved_module_shape};
@@ -51,6 +50,10 @@ pub(crate) fn module_from_constructor_call(
         return None;
     };
 
+    if imports.is_torch_nn_storage_constructor(call.func.as_ref()) {
+        return None;
+    }
+
     if let Some(class_ref) = constructor_class_ref(
         call.func.as_ref(),
         class_map,
@@ -61,10 +64,7 @@ pub(crate) fn module_from_constructor_call(
         return Some(ResolvedModule::User(class_ref));
     }
 
-    let constructor_name = torch_nn_constructor_name(call_expr, imports)?;
-    if constructor_name == "Parameter" || constructor_name == "Buffer" {
-        return None;
-    }
+    torch_nn_constructor_name(call_expr, imports)?;
     Some(ResolvedModule::Builtin(
         TorchNNModule::from_constructor_call(
             call_expr,
@@ -299,7 +299,7 @@ fn torch_nn_constructor_name(call_expr: &Expr, imports: &Imports) -> Option<Stri
         Expr::Name(name) => imports
             .imported_symbol_from(&name.id, "torch.nn")
             .map(ToString::to_string),
-        Expr::Attribute(attr) if is_torch_nn_namespace(attr.value.as_ref(), imports) => {
+        Expr::Attribute(attr) if imports.is_torch_nn_namespace_expr(attr.value.as_ref()) => {
             Some(attr.attr.to_string())
         }
         _ => None,

--- a/src/torch_nn.rs
+++ b/src/torch_nn.rs
@@ -1,0 +1,378 @@
+use crate::infer::{infer_batchnorm_module, infer_conv_module, infer_linear_module};
+use crate::module_resolution::{
+    ClassMap, ClassRef, FuncMap, ModuleCache, ResolvedModule, imported_class_ref,
+};
+use crate::op_groups::Imports;
+use crate::{HoverInfo, Shape, VarState, infer_resolved_module_shape};
+use lsp_types::{Diagnostic, Range};
+use rustpython_parser::ast::{Expr, ExprCall, Identifier, Operator};
+use rustpython_parser::text_size::TextRange;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Attribute in __init__ parsed into a builtin `torch.nn.Module`.
+#[derive(Debug, Clone)]
+pub(crate) enum TorchNNModule {
+    Linear {
+        in_features: Option<String>,
+        out_features: Option<String>,
+    },
+    BatchNorm {
+        dims: usize,
+        num_features: Option<String>,
+    },
+    Conv {
+        dims: usize,
+        in_channels: Option<String>,
+        out_channels: Option<String>,
+        kernel_size: Vec<String>,
+        stride: Vec<String>,
+        padding: Vec<String>,
+        dilation: Vec<String>,
+        groups: Option<String>,
+    },
+    Sequential(Vec<ResolvedModule>),
+    /// Any unknown identifier from torch.nn.*, is parsed as Noop.
+    Noop,
+}
+
+pub(crate) fn module_from_constructor_call(
+    call_expr: &Expr,
+    class_map: &ClassMap,
+    imports: &Imports,
+    mut module_cache: Option<&mut ModuleCache>,
+    module_path: Option<&Path>,
+) -> Option<ResolvedModule> {
+    let Expr::Call(call) = call_expr else {
+        return None;
+    };
+
+    match call.func.as_ref() {
+        Expr::Name(name) => {
+            if class_map.contains_key(&name.id) {
+                return Some(ResolvedModule::User(ClassRef {
+                    name: name.id.clone(),
+                    module: None,
+                }));
+            }
+            if let Some((module_name, original)) = imports.from_imports.get(&name.id) {
+                if module_name == "torch.nn" {
+                    if original.as_str() == "Parameter" {
+                        return None;
+                    }
+                    return Some(ResolvedModule::Builtin(
+                        TorchNNModule::from_constructor_call(
+                            call_expr,
+                            class_map,
+                            imports,
+                            module_cache,
+                            module_path,
+                        ),
+                    ));
+                }
+                if let Some(class_ref) = imported_class_ref(
+                    module_name,
+                    original,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) {
+                    return Some(ResolvedModule::User(class_ref));
+                }
+            }
+        }
+        Expr::Attribute(attr) => {
+            if is_torch_nn_constructor(call_expr, imports) {
+                if attr.attr.as_str() == "Parameter" {
+                    return None;
+                }
+                return Some(ResolvedModule::Builtin(
+                    TorchNNModule::from_constructor_call(
+                        call_expr,
+                        class_map,
+                        imports,
+                        module_cache,
+                        module_path,
+                    ),
+                ));
+            }
+            if let Expr::Name(module_ident) = attr.value.as_ref()
+                && let Some(module_name) = imports.module_aliases.get(&module_ident.id)
+                && let Some(class_ref) =
+                    imported_class_ref(module_name, &attr.attr, module_cache, module_path)
+            {
+                return Some(ResolvedModule::User(class_ref));
+            }
+        }
+        _ => {}
+    }
+
+    None
+}
+
+impl TorchNNModule {
+    pub(crate) fn from_constructor_call(
+        call_expr: &Expr,
+        class_map: &ClassMap,
+        imports: &Imports,
+        mut module_cache: Option<&mut ModuleCache>,
+        module_path: Option<&Path>,
+    ) -> Self {
+        let Expr::Call(call) = call_expr else {
+            return Self::Noop;
+        };
+        let Some(constructor_name) = torch_nn_constructor_name(call_expr, imports) else {
+            return Self::Noop;
+        };
+        let normalized = constructor_name.to_ascii_lowercase();
+
+        if normalized == "linear" {
+            return Self::Linear {
+                in_features: get_call_arg(call, "in_features", 0).and_then(expr_to_token),
+                out_features: get_call_arg(call, "out_features", 1).and_then(expr_to_token),
+            };
+        }
+
+        if normalized.starts_with("batchnorm")
+            && let Some(dims) = parse_module_dims(&normalized, "batchnorm")
+        {
+            return Self::BatchNorm {
+                dims,
+                num_features: get_call_arg(call, "num_features", 0).and_then(expr_to_token),
+            };
+        }
+
+        if normalized.starts_with("conv")
+            && let Some(dims) = parse_module_dims(&normalized, "conv")
+        {
+            return Self::Conv {
+                dims,
+                in_channels: get_call_arg(call, "in_channels", 0).and_then(expr_to_token),
+                out_channels: get_call_arg(call, "out_channels", 1).and_then(expr_to_token),
+                kernel_size: get_call_arg(call, "kernel_size", 2)
+                    .and_then(expr_to_tokens)
+                    .unwrap_or_default(),
+                stride: get_call_arg(call, "stride", 3)
+                    .and_then(expr_to_tokens)
+                    .unwrap_or_default(),
+                padding: get_call_arg(call, "padding", 4)
+                    .and_then(expr_to_tokens)
+                    .unwrap_or_default(),
+                dilation: get_call_arg(call, "dilation", 5)
+                    .and_then(expr_to_tokens)
+                    .unwrap_or_default(),
+                groups: get_call_arg(call, "groups", 6).and_then(expr_to_token),
+            };
+        }
+
+        if normalized == "sequential" {
+            let mut modules = Vec::new();
+            for element in sequential_elements(call) {
+                if let Some(module) = module_from_constructor_call(
+                    element,
+                    class_map,
+                    imports,
+                    module_cache.as_deref_mut(),
+                    module_path,
+                ) {
+                    modules.push(module);
+                }
+            }
+            return Self::Sequential(modules);
+        }
+
+        Self::Noop
+    }
+
+    pub(crate) fn infer_builtin_module(
+        &self,
+        base_shape: Shape,
+        vars: &HashMap<Identifier, VarState>,
+        func_map: &FuncMap,
+        imports: &Imports,
+        class_map: &ClassMap,
+        call_stack: &mut Vec<Identifier>,
+        diagnostics: &mut Vec<Diagnostic>,
+        hover_entries: &mut Vec<(Range, HoverInfo)>,
+        source: &str,
+        range: TextRange,
+        mut module_cache: Option<&mut ModuleCache>,
+        module_path: Option<&Path>,
+    ) -> Option<Shape> {
+        match self {
+            Self::Linear {
+                in_features,
+                out_features,
+            } => infer_linear_module(
+                base_shape,
+                in_features.as_deref(),
+                out_features.as_deref(),
+                range,
+                diagnostics,
+                source,
+            ),
+            Self::BatchNorm { dims, num_features } => infer_batchnorm_module(
+                base_shape,
+                *dims,
+                num_features.as_deref(),
+                range,
+                diagnostics,
+                source,
+            ),
+            Self::Conv {
+                dims,
+                in_channels,
+                out_channels,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                groups,
+            } => infer_conv_module(
+                base_shape,
+                *dims,
+                in_channels.as_deref(),
+                out_channels.as_deref(),
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                groups.as_deref(),
+                range,
+                diagnostics,
+                source,
+            ),
+            Self::Sequential(modules) => {
+                let mut current = base_shape;
+                for module in modules {
+                    current = infer_resolved_module_shape(
+                        module,
+                        current,
+                        vars,
+                        func_map,
+                        imports,
+                        class_map,
+                        call_stack,
+                        diagnostics,
+                        hover_entries,
+                        source,
+                        range,
+                        module_cache.as_deref_mut(),
+                        module_path,
+                    )?;
+                }
+                Some(current)
+            }
+            Self::Noop => Some(base_shape),
+        }
+    }
+}
+
+fn get_call_arg<'a>(call: &'a ExprCall, name_arg: &str, as_positional: usize) -> Option<&'a Expr> {
+    call.args.get(as_positional).or_else(|| {
+        call.keywords
+            .iter()
+            .find(|kw| kw.arg.as_deref() == Some(name_arg))
+            .map(|kw| &kw.value)
+    })
+}
+
+fn is_torch_nn_constructor(call_expr: &Expr, imports: &Imports) -> bool {
+    torch_nn_constructor_name(call_expr, imports).is_some()
+}
+
+fn torch_nn_constructor_name(call_expr: &Expr, imports: &Imports) -> Option<String> {
+    let Expr::Call(call) = call_expr else {
+        return None;
+    };
+    match call.func.as_ref() {
+        Expr::Name(name) => imports
+            .from_imports
+            .get(&name.id)
+            .filter(|(module_name, _)| module_name == "torch.nn")
+            .map(|(_, original)| original.to_string()),
+        Expr::Attribute(attr) => match attr.value.as_ref() {
+            Expr::Name(module_ident) => imports
+                .module_aliases
+                .get(&module_ident.id)
+                .filter(|module_name| module_name.as_str() == "torch.nn")
+                .map(|_| attr.attr.to_string()),
+            Expr::Attribute(nn_attr) if nn_attr.attr.as_str() == "nn" => {
+                if let Expr::Name(torch_name) = nn_attr.value.as_ref()
+                    && imports.torch_aliases.contains(&torch_name.id)
+                {
+                    return Some(attr.attr.to_string());
+                }
+                None
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn parse_module_dims(name: &str, prefix: &str) -> Option<usize> {
+    name.strip_prefix(prefix)?
+        .trim_end_matches('d')
+        .parse::<usize>()
+        .ok()
+}
+
+fn sequential_elements(call: &ExprCall) -> Vec<&Expr> {
+    if call.args.len() == 1 {
+        match &call.args[0] {
+            Expr::Tuple(tuple) => return tuple.elts.iter().collect(),
+            Expr::List(list) => return list.elts.iter().collect(),
+            _ => {}
+        }
+    }
+    call.args.iter().collect()
+}
+
+fn expr_to_tokens(expr: &Expr) -> Option<Vec<String>> {
+    match expr {
+        Expr::Tuple(tuple) => tuple.elts.iter().map(expr_to_token).collect(),
+        Expr::List(list) => list.elts.iter().map(expr_to_token).collect(),
+        other => expr_to_token(other).map(|token| vec![token]),
+    }
+}
+
+fn expr_to_token(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Name(name) => Some(name.id.to_string()),
+        Expr::Constant(constant) => match &constant.value {
+            rustpython_parser::ast::Constant::Int(int) => Some(int.to_string()),
+            rustpython_parser::ast::Constant::Float(float) => Some(float.to_string()),
+            rustpython_parser::ast::Constant::Str(string) => Some(string.to_string()),
+            _ => None,
+        },
+        Expr::Attribute(attr) => Some(attr.attr.to_string()),
+        Expr::UnaryOp(unary) => match unary.op {
+            rustpython_parser::ast::UnaryOp::USub => {
+                expr_to_token(unary.operand.as_ref()).map(|token| format!("-{token}"))
+            }
+            rustpython_parser::ast::UnaryOp::UAdd => expr_to_token(unary.operand.as_ref()),
+            _ => None,
+        },
+        Expr::BinOp(bin) => {
+            let left = expr_to_token(bin.left.as_ref())?;
+            let right = expr_to_token(bin.right.as_ref())?;
+            let op = match bin.op {
+                Operator::Add => "+",
+                Operator::Sub => "-",
+                Operator::Mult => "*",
+                Operator::Div | Operator::FloorDiv => "/",
+                _ => return None,
+            };
+            Some(format!("{left}{op}{right}"))
+        }
+        Expr::Call(call) => {
+            if let Expr::Name(name) = call.func.as_ref()
+                && name.id.as_str() == "int"
+            {
+                return call.args.first().and_then(expr_to_token);
+            }
+            None
+        }
+        _ => None,
+    }
+}

--- a/src/torch_nn.rs
+++ b/src/torch_nn.rs
@@ -1,6 +1,7 @@
 use crate::infer::{infer_batchnorm_module, infer_conv_module, infer_linear_module};
 use crate::module_resolution::{
     ClassMap, ClassRef, FuncMap, ModuleCache, ResolvedModule, imported_class_ref,
+    is_torch_nn_namespace,
 };
 use crate::op_groups::Imports;
 use crate::{HoverInfo, Shape, VarState, infer_resolved_module_shape};
@@ -293,26 +294,11 @@ fn torch_nn_constructor_name(call_expr: &Expr, imports: &Imports) -> Option<Stri
     };
     match call.func.as_ref() {
         Expr::Name(name) => imports
-            .from_imports
-            .get(&name.id)
-            .filter(|(module_name, _)| module_name == "torch.nn")
-            .map(|(_, original)| original.to_string()),
-        Expr::Attribute(attr) => match attr.value.as_ref() {
-            Expr::Name(module_ident) => imports
-                .module_aliases
-                .get(&module_ident.id)
-                .filter(|module_name| module_name.as_str() == "torch.nn")
-                .map(|_| attr.attr.to_string()),
-            Expr::Attribute(nn_attr) if nn_attr.attr.as_str() == "nn" => {
-                if let Expr::Name(torch_name) = nn_attr.value.as_ref()
-                    && imports.torch_aliases.contains(&torch_name.id)
-                {
-                    return Some(attr.attr.to_string());
-                }
-                None
-            }
-            _ => None,
-        },
+            .imported_symbol_from(&name.id, "torch.nn")
+            .map(ToString::to_string),
+        Expr::Attribute(attr) if is_torch_nn_namespace(attr.value.as_ref(), imports) => {
+            Some(attr.attr.to_string())
+        }
         _ => None,
     }
 }

--- a/src/torch_nn/known_nn_modules.rs
+++ b/src/torch_nn/known_nn_modules.rs
@@ -1,0 +1,60 @@
+use phf::Set;
+use phf_macros::phf_set;
+
+/// Builtin `torch.nn.Module`s that are safe to treat as shape no-ops.
+///
+/// This list intentionally excludes:
+/// - modules that change shape or rank, such as pooling/padding/flattening;
+/// - modules that return non-tensor structures, such as attention or losses;
+/// - modules with dedicated parsing/inference elsewhere, such as `BatchNorm*d`;
+/// - wrappers/containers rather than direct tensor operations.
+pub static NOOP_NN_MODULES: Set<&'static str> = phf_set![
+    "ELU",
+    "Hardshrink",
+    "Hardsigmoid",
+    "Hardtanh",
+    "Hardswish",
+    "LeakyReLU",
+    "LogSigmoid",
+    "PReLU",
+    "ReLU",
+    "ReLU6",
+    "RReLU",
+    "SELU",
+    "CELU",
+    "GELU",
+    "Sigmoid",
+    "SiLU",
+    "Mish",
+    "Softplus",
+    "Softshrink",
+    "Softsign",
+    "Tanh",
+    "Tanhshrink",
+    "Threshold",
+    "Softmin",
+    "Softmax",
+    "Softmax2d",
+    "LogSoftmax",
+    "LazyBatchNorm1d",
+    "LazyBatchNorm2d",
+    "LazyBatchNorm3d",
+    "GroupNorm",
+    "SyncBatchNorm",
+    "LazyInstanceNorm1d",
+    "InstanceNorm1d",
+    "LazyInstanceNorm2d",
+    "InstanceNorm2d",
+    "LazyInstanceNorm3d",
+    "InstanceNorm3d",
+    "LayerNorm",
+    "LocalResponseNorm",
+    "RMSNorm",
+    "Identity",
+    "Dropout",
+    "Dropout1d",
+    "Dropout2d",
+    "Dropout3d",
+    "AlphaDropout",
+    "FeatureAlphaDropout",
+];

--- a/src/torch_nn/mod.rs
+++ b/src/torch_nn/mod.rs
@@ -13,6 +13,8 @@ use rustpython_parser::text_size::TextRange;
 use std::collections::HashMap;
 use std::path::Path;
 
+pub(crate) mod known_nn_modules;
+
 /// Attribute in __init__ parsed into a builtin `torch.nn.Module`.
 #[derive(Debug, Clone)]
 pub(crate) enum TorchNNModule {
@@ -35,8 +37,11 @@ pub(crate) enum TorchNNModule {
         groups: Option<String>,
     },
     Sequential(Vec<ResolvedModule>),
-    /// Any unknown identifier from torch.nn.*, is parsed as Noop.
+    /// `torch.nn.Module` that do not change shapes and do not require
+    /// custom checks (or the checks are not yet implemented).
     Noop,
+    /// `torch.nn.Module` not implemented or unkown.
+    Unknown,
 }
 
 pub(crate) fn module_from_constructor_call(
@@ -85,10 +90,10 @@ impl TorchNNModule {
         module_path: Option<&Path>,
     ) -> Self {
         let Expr::Call(call) = call_expr else {
-            return Self::Noop;
+            return Self::Unknown;
         };
         let Some(constructor_name) = torch_nn_constructor_name(call_expr, imports) else {
-            return Self::Noop;
+            return Self::Unknown;
         };
         Self::from_named_constructor(
             call,
@@ -166,7 +171,11 @@ impl TorchNNModule {
             );
         }
 
-        Self::Noop
+        if known_nn_modules::NOOP_NN_MODULES.contains(constructor_name) {
+            Self::Noop
+        } else {
+            Self::Unknown
+        }
     }
 
     pub(crate) fn infer_builtin_module(
@@ -248,7 +257,7 @@ impl TorchNNModule {
                 }
                 Some(current)
             }
-            Self::Noop => Some(base_shape),
+            Self::Noop | Self::Unknown => Some(base_shape),
         }
     }
 }
@@ -298,6 +307,7 @@ fn torch_nn_constructor_name(call_expr: &Expr, imports: &Imports) -> Option<Stri
     match call.func.as_ref() {
         Expr::Name(name) => imports
             .imported_symbol_from(&name.id, "torch.nn")
+            .or_else(|| imports.imported_torch_nn_noop(&name.id))
             .map(ToString::to_string),
         Expr::Attribute(attr) if imports.is_torch_nn_namespace_expr(attr.value.as_ref()) => {
             Some(attr.attr.to_string())

--- a/src/torch_nn/mod.rs
+++ b/src/torch_nn/mod.rs
@@ -40,7 +40,7 @@ pub(crate) enum TorchNNModule {
     /// `torch.nn.Module` that do not change shapes and do not require
     /// custom checks (or the checks are not yet implemented).
     Noop,
-    /// `torch.nn.Module` not implemented or unkown.
+    /// `torch.nn.Module` not implemented or unknown.
     Unknown,
 }
 

--- a/test_data/bench_lsp/blocks.py
+++ b/test_data/bench_lsp/blocks.py
@@ -6,7 +6,7 @@ from helpers import gated_update, mlp_update, normalize_like, residual_add
 
 
 class ResidualBlock(nn.Module):
-    """Unnannotated, will run inference from the caller to the forward body."""
+    """Unannotated, will run inference from the caller to the forward body."""
     def forward(self, x, up, down, gate):
         mixed = mlp_update(x, up, down)
         gated = gated_update(mixed, gate)

--- a/test_data/bench_lsp/blocks.py
+++ b/test_data/bench_lsp/blocks.py
@@ -1,0 +1,37 @@
+import torch.nn as nn
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+from helpers import gated_update, mlp_update, normalize_like, residual_add
+
+
+class ResidualBlock(nn.Module):
+    """Unnannotated, will run inference from the caller to the forward body."""
+    def forward(self, x, up, down, gate):
+        mixed = mlp_update(x, up, down)
+        gated = gated_update(mixed, gate)
+        out = residual_add(normalize_like(mixed), gated)
+        return out
+
+
+class EncoderStage(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = ResidualBlock()
+
+    def forward(
+        self,
+        x: F[T, "B T H"],
+        up: F[T, "H M"],
+        down: F[T, "M H"],
+        gate: F[T, "H H"],
+    ) -> F[T, "B T H"]:
+        h1 = self.block(x, up, down, gate)
+        h2 = self.block(h1, up, down, gate)
+        return h2
+
+
+class ProjectionHead(nn.Module):
+    def forward(self, x: F[T, "B T H"], proj: F[T, "H O"]) -> F[T, "B T O"]:
+        logits = x @ proj
+        return logits

--- a/test_data/bench_lsp/blocks_alt.py
+++ b/test_data/bench_lsp/blocks_alt.py
@@ -1,0 +1,44 @@
+import torch.nn as nn
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+from helpers import gated_update, mlp_update, normalize_like, residual_add
+
+
+class ResidualBlock(nn.Module):
+    def forward(
+        self,
+        x: F[T, "B T H"],
+        up: F[T, "H M"],
+        down: F[T, "M H"],
+        gate: F[T, "H H"],
+    ) -> F[T, "B T H"]:
+        base = normalize_like(x)
+        updated = mlp_update(base, up, down)
+        mixed = gated_update(updated, gate)
+        out = residual_add(updated, mixed)
+        return out
+
+
+class EncoderStage(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = ResidualBlock()
+
+    def forward(
+        self,
+        x: F[T, "B T H"],
+        up: F[T, "H M"],
+        down: F[T, "M H"],
+        gate: F[T, "H H"],
+    ) -> F[T, "B T H"]:
+        h1 = self.block(x, up, down, gate)
+        h2 = normalize_like(self.block(h1, up, down, gate))
+        return h2
+
+
+class ProjectionHead(nn.Module):
+    def forward(self, x: F[T, "B T H"], proj: F[T, "H O"]) -> F[T, "B T O"]:
+        activated = normalize_like(x)
+        logits = activated @ proj
+        return logits

--- a/test_data/bench_lsp/helpers.py
+++ b/test_data/bench_lsp/helpers.py
@@ -1,0 +1,30 @@
+import torch
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+
+def residual_add(x: F[T, "B T H"], y: F[T, "B T H"]) -> F[T, "B T H"]:
+    out = x + y
+    return out
+
+
+def project_features(x: F[T, "B T H"], w: F[T, "H O"]) -> F[T, "B T O"]:
+    out = x @ w
+    return out
+
+
+def gated_update(x: F[T, "B T H"], gate: F[T, "H H"]) -> F[T, "B T H"]:
+    gated = x @ gate
+    return gated
+
+
+def mlp_update(x, up, down):
+    """Unannotated, calling site will resolve to inference through here."""
+    hidden = project_features(x, up)
+    hidden = torch.relu(hidden)
+    update = project_features(hidden, down)
+    return residual_add(x, update)
+
+
+def normalize_like(x: F[T, "B T H"]) -> F[T, "B T H"]:
+    return torch.relu(x)

--- a/test_data/bench_lsp/model.py
+++ b/test_data/bench_lsp/model.py
@@ -1,0 +1,115 @@
+import torch
+import torch.nn as nn
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+from blocks import EncoderStage, ProjectionHead
+from helpers import mlp_update, normalize_like, project_features, residual_add
+
+
+def encode_once(
+    x: F[T, "B T H"],
+    stage: EncoderStage,
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+    gate: F[T, "H H"],
+) -> F[T, "B T H"]:
+    out = stage(x, up, down, gate)
+    return out
+
+
+def encode_twice(
+    x: F[T, "B T H"],
+    stage: EncoderStage,
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+    gate: F[T, "H H"],
+) -> F[T, "B T H"]:
+    h1 = encode_once(x, stage, up, down, gate)
+    h2 = encode_once(h1, stage, up, down, gate)
+    return h2
+
+
+def feedforward_pass(
+    x: F[T, "B T H"],
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+) -> F[T, "B T H"]:
+    updated = mlp_update(x, up, down)
+    return updated
+
+
+def fused_pass(
+    x: F[T, "B T H"],
+    stage: EncoderStage,
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+    gate: F[T, "H H"],
+) -> F[T, "B T H"]:
+    h1 = feedforward_pass(x, up, down)
+    h2 = stage(h1, up, down, gate)
+    h3 = residual_add(h1, h2)
+    return normalize_like(h3)
+
+
+class MacroModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.stage_a = EncoderStage()
+        self.stage_b = EncoderStage()
+        self.head = ProjectionHead()
+
+    def forward(
+        self,
+        x: F[T, "B T H"],
+        up: F[T, "H M"],
+        down: F[T, "M H"],
+        gate: F[T, "H H"],
+        proj: F[T, "H O"],
+    ) -> F[T, "B T O"]:
+        h0 = normalize_like(x)
+        h1 = self.stage_a(h0, up, down, gate)
+        h2 = residual_add(h0, h1)
+        h3 = self.stage_b(h2, up, down, gate)
+        logits = self.head(h3, proj)
+        return logits
+
+
+def run_pipeline():
+    B, T, H, M, O = 8, 128, 256, 512, 64
+    x: F[T, "B T H"] = torch.zeros(B, T, H)
+    up: F[T, "H M"] = torch.zeros(H, M)
+    down: F[T, "M H"] = torch.zeros(M, H)
+    gate: F[T, "H H"] = torch.zeros(H, H)
+    proj: F[T, "H O"] = torch.zeros(H, O)
+    model = MacroModel()
+    logits = model(x, up, down, gate, proj)
+    return logits
+
+
+def run_pipeline_variant():
+    B, T, H, M, O = 4, 64, 128, 256, 32
+    x: F[T, "B T H"] = torch.zeros(B, T, H)
+    up: F[T, "H M"] = torch.zeros(H, M)
+    down: F[T, "M H"] = torch.zeros(M, H)
+    gate: F[T, "H H"] = torch.zeros(H, H)
+    proj: F[T, "H O"] = torch.zeros(H, O)
+    stage = EncoderStage()
+    hidden = encode_twice(x, stage, up, down, gate)
+    fused = fused_pass(hidden, stage, up, down, gate)
+    logits = project_features(fused, proj)
+    return logits
+
+
+def run_pipeline_small():
+    B, T, H, M, O = 2, 32, 64, 128, 16
+    x: F[T, "B T H"] = torch.zeros(B, T, H)
+    up: F[T, "H M"] = torch.zeros(H, M)
+    down: F[T, "M H"] = torch.zeros(M, H)
+    gate: F[T, "H H"] = torch.zeros(H, H)
+    proj: F[T, "H O"] = torch.zeros(H, O)
+    stage = EncoderStage()
+    hidden = encode_once(x, stage, up, down, gate)
+    hidden = residual_add(hidden, stage(hidden, up, down, gate))
+    logits = project_features(hidden, proj)
+    return logits

--- a/test_data/bench_lsp/model_alt.py
+++ b/test_data/bench_lsp/model_alt.py
@@ -1,0 +1,115 @@
+import torch
+import torch.nn as nn
+from jaxtyping import Float as F
+from torch import Tensor as T
+
+from blocks import EncoderStage, ProjectionHead
+from helpers import mlp_update, normalize_like, project_features, residual_add
+
+
+def encode_once(
+    x: F[T, "B T H"],
+    stage: EncoderStage,
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+    gate: F[T, "H H"],
+) -> F[T, "B T H"]:
+    out = normalize_like(stage(x, up, down, gate))
+    return out
+
+
+def encode_twice(
+    x: F[T, "B T H"],
+    stage: EncoderStage,
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+    gate: F[T, "H H"],
+) -> F[T, "B T H"]:
+    h1 = encode_once(x, stage, up, down, gate)
+    h2 = encode_once(h1, stage, up, down, gate)
+    return residual_add(h1, h2)
+
+
+def feedforward_pass(
+    x: F[T, "B T H"],
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+) -> F[T, "B T H"]:
+    base = normalize_like(x)
+    updated = mlp_update(base, up, down)
+    return residual_add(base, updated)
+
+
+def fused_pass(
+    x: F[T, "B T H"],
+    stage: EncoderStage,
+    up: F[T, "H M"],
+    down: F[T, "M H"],
+    gate: F[T, "H H"],
+) -> F[T, "B T H"]:
+    h1 = stage(normalize_like(x), up, down, gate)
+    h2 = feedforward_pass(h1, up, down)
+    return residual_add(h1, h2)
+
+
+class MacroModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.stage_a = EncoderStage()
+        self.stage_b = EncoderStage()
+        self.head = ProjectionHead()
+
+    def forward(
+        self,
+        x: F[T, "B T H"],
+        up: F[T, "H M"],
+        down: F[T, "M H"],
+        gate: F[T, "H H"],
+        proj: F[T, "H O"],
+    ) -> F[T, "B T O"]:
+        h0 = residual_add(normalize_like(x), x)
+        h1 = self.stage_a(h0, up, down, gate)
+        h2 = normalize_like(residual_add(h0, h1))
+        h3 = self.stage_b(h2, up, down, gate)
+        mixed = residual_add(h2, h3)
+        logits = self.head(mixed, proj)
+        return logits
+
+
+def run_pipeline():
+    B, T, H, M, O = 8, 128, 256, 512, 64
+    x: F[T, "B T H"] = torch.zeros(B, T, H)
+    up: F[T, "H M"] = torch.zeros(H, M)
+    down: F[T, "M H"] = torch.zeros(M, H)
+    gate: F[T, "H H"] = torch.zeros(H, H)
+    proj: F[T, "H O"] = torch.zeros(H, O)
+    model = MacroModel()
+    logits = model(x, up, down, gate, proj)
+    return logits
+
+
+def run_pipeline_variant():
+    B, T, H, M, O = 4, 64, 128, 256, 32
+    x: F[T, "B T H"] = torch.zeros(B, T, H)
+    up: F[T, "H M"] = torch.zeros(H, M)
+    down: F[T, "M H"] = torch.zeros(M, H)
+    gate: F[T, "H H"] = torch.zeros(H, H)
+    proj: F[T, "H O"] = torch.zeros(H, O)
+    stage = EncoderStage()
+    hidden = fused_pass(x, stage, up, down, gate)
+    logits = project_features(hidden, proj)
+    return logits
+
+
+def run_pipeline_small():
+    B, T, H, M, O = 2, 32, 64, 128, 16
+    x: F[T, "B T H"] = torch.zeros(B, T, H)
+    up: F[T, "H M"] = torch.zeros(H, M)
+    down: F[T, "M H"] = torch.zeros(M, H)
+    gate: F[T, "H H"] = torch.zeros(H, H)
+    proj: F[T, "H O"] = torch.zeros(H, O)
+    stage = EncoderStage()
+    hidden = encode_once(x, stage, up, down, gate)
+    hidden = normalize_like(residual_add(hidden, stage(hidden, up, down, gate)))
+    logits = project_features(hidden, proj)
+    return logits

--- a/test_data/class.py
+++ b/test_data/class.py
@@ -556,3 +556,37 @@ class ImportedParameterAndBuffer(nn.Module):
     def forward(self, x: F[T, "B X 32"]):
         y = x @ self.weight + self.bias
         return y
+
+
+# test 30
+from jaxtyping import Float as F
+from torch import Tensor as T
+from torch.nn import ReLU as Act
+import torch.nn as nn
+
+
+class ImportedAliasedNoopModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.act = Act()
+
+    def forward(self, x: F[T, "B X 32"]):
+        y = self.act(x)
+        return y
+
+
+# test 31
+from jaxtyping import Float as F
+from torch import Tensor as T
+from torch.nn import *
+import torch.nn as nn
+
+
+class ImportedStarNoopModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.act = ReLU()
+
+    def forward(self, x: F[T, "B X 32"]):
+        y = self.act(x)
+        return y

--- a/test_data/class.py
+++ b/test_data/class.py
@@ -427,3 +427,113 @@ def ellipsis_tuple_destructuring(module: EllipsisTuple, x: F[Tensor, "Batch Head
     y, residual = module(x)
     return y, residual
 
+
+# test 23
+from jaxtyping import Float as F
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class BuiltinLinearModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(7, 11)
+
+    def forward(self, x: F[T, "B X 7"]):
+        z = self.proj(x)
+        return z
+
+
+# test 24
+from jaxtyping import Float as F
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class BuiltinLinearModelAbstract(nn.Module):
+    def __init__(self):
+        super().__init__()
+        Y, Z = 7, 14
+        self.proj = nn.Linear(Y, Z)
+
+    def forward(self, x: F[T, "B X Y"]):
+        z = self.proj(x)
+        return z
+
+# test 25
+from jaxtyping import Float as F
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class BuiltinLinearModelAbstractWrong(nn.Module):
+    def __init__(self):
+        super().__init__()
+        Out = 14
+        self.proj = nn.Linear(7, Out)
+
+    def forward(self, x: F[T, "B X 5"]):
+        # wrong, doesn't type check
+        z = self.proj(x)
+        return z
+
+
+# test 26
+from jaxtyping import Float as F
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class BuiltinLinearModelConcreteAlphaEquiv(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Sequential(
+            nn.Linear(7, 12),
+            nn.ReLU(),
+        )   
+    
+    def forward(self, x: F[T, "B X Y"]):
+        # B X 12
+        z = self.proj(x)
+        return z
+
+
+# test 27
+from jaxtyping import Float as F
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class BuiltinSequentialCovModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        OutCh = 16
+        self.net = nn.Sequential(
+            nn.Conv2d(3, OutCh, 3, padding=1),
+            nn.BatchNorm2d(16),
+            nn.ReLU(),
+        )
+
+    def forward(self, x: F[T, "B 3 H W"]):
+        y = self.net(x)
+        return y
+
+
+# test 28
+from jaxtyping import Float as F
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class BuiltinSequentialCovModelWrong(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(3, 16, 3, padding=1),
+            nn.BatchNorm2d(16),
+            nn.ReLU(),
+        )
+
+    def forward(self, x: F[T, "B 5 H W"]):
+        y = self.net(x)
+        return y

--- a/test_data/class.py
+++ b/test_data/class.py
@@ -537,3 +537,22 @@ class BuiltinSequentialCovModelWrong(nn.Module):
     def forward(self, x: F[T, "B 5 H W"]):
         y = self.net(x)
         return y
+
+
+# test 29
+from jaxtyping import Float as F
+from torch import Tensor as T
+from torch.nn import Buffer as Buf, Parameter as Param
+import torch
+import torch.nn as nn
+
+
+class ImportedParameterAndBuffer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = Param(torch.ones(32, 57))
+        self.bias = Buf(torch.ones(57))
+
+    def forward(self, x: F[T, "B X 32"]):
+        y = x @ self.weight + self.bias
+        return y

--- a/test_data/conv.py
+++ b/test_data/conv.py
@@ -58,7 +58,7 @@ def wrong_conv1d():
 
 # test 6
 import torch
-import torch.nn as nn
+from torch import nn
 
 def infer_conv1d_module():
     x = torch.ones(32, 256, 512)

--- a/test_data/conv.py
+++ b/test_data/conv.py
@@ -83,7 +83,8 @@ import torch.nn as nn
 
 
 class Conv3dModule(nn.Module):
-    def __init__(self,):
+    def __init__(self):
+        super().__init__()
         self.filter = nn.Conv3d(4, 8, (3, 5, 7), stride=(2, 3, 4), padding=(1, 2, 3), dilation=(1, 2, 1))
         self.out_layer = nn.Sequential(
             nn.SiLU()

--- a/test_data/conv.py
+++ b/test_data/conv.py
@@ -55,3 +55,67 @@ def wrong_conv1d():
     kernel = torch.ones(18, 256, 9)
     out = conv1d(x, kernel)
     return out
+
+# test 6
+import torch
+import torch.nn as nn
+
+def infer_conv1d_module():
+    x = torch.ones(32, 256, 512)
+    conv = nn.Conv1d(256, 128, 3)
+    out = conv(x)
+    return out
+
+# test 7
+import torch
+import torch.nn as nn
+
+x = torch.ones(32, 256, H, W, dtype=torch.float)   # H, W arbitrary spatial sizes
+conv = nn.Conv2d(256, 128, 3, stride=2, padding=6, dilation=3)
+
+y = conv(x)
+
+# test 8
+import torch
+from jaxtyping import Float
+from torch import Tensor as T
+import torch.nn as nn
+
+
+class Conv3dModule(nn.Module):
+    def __init__(self,):
+        self.filter = nn.Conv3d(4, 8, (3, 5, 7), stride=(2, 3, 4), padding=(1, 2, 3), dilation=(1, 2, 1))
+        self.out_layer = nn.Sequential(
+            nn.SiLU()
+        )
+        self.param = nn.Parameter(torch.ones(10, 128))
+
+    def forward(self, x):
+        return self.out_layer(self.filter(x)) @ self.param
+
+        
+def infer_conv3d_module_allconcrete(x: Float[T, "2 4 20 30 40"]):
+    conv = Conv3dModule()
+    y = conv(x)
+
+
+# test 9
+import torch
+from jaxtyping import Float
+from torch import Tensor as T
+import torch.nn as nn
+
+def infer_conv3d_module_mixed(x: Float[T, "2 4 20 30 40"]):
+    conv = nn.Conv3d(4, 8, (3, 5, 7), stride=(S, 3, 4), padding=(1, P, 3), dilation=(1, D, 1))
+    y = conv(x)
+
+
+# test 10
+import torch
+import torch.nn as nn
+
+def wrong_conv1d_module():
+    x = torch.ones(512)
+    conv = nn.Conv1d(256, 18, 9)
+    out = conv(x)
+    return out


### PR DESCRIPTION
Closes #3 

### Description

After #20, `self.*` attribute assignments at `__init__` are tracked and then resolved at inference for `torch.nn.Parameter`, tensors and user-defined `torch.nn.Module`s. This PR implements custom support for some native built-in `torch.nn.Module`s.

### Implementation

A self attribute assginements resolved to a `ResolvedModule` (omitting tensors or parameters), which can be user-defined or built-in.
User-defined are resolved as before while built-in are now parsed into an enum `TorchNNModule`, enumerating implemented `torch.nn.Module`s. At inference, each case is mapped to its respective inference functions (piggybacking on `src/infer.rs`).

* Implemented built-ins: `Linear`, `BatchNorm*`, `Sequential`, `Conv` and all activation functions and similar operations that are a no-op shape-wise (it would be nice to implement checks for some of them, left for the future).
* Support for `Buffer`, treated exactly as `Parameter`.\
* `nn`, `functional`, `Buffer` and `Parameter` now are passed into `Imports` to improve robustness under renaming on imports, etc.
* New benchmarks and tests were added.